### PR TITLE
chore(cb2-6442): improve logging verbosity

### DIFF
--- a/src/main/java/uk/gov/dvsa/PdfGenerator.java
+++ b/src/main/java/uk/gov/dvsa/PdfGenerator.java
@@ -46,7 +46,6 @@ public class PdfGenerator implements RequestHandler<Map<String, Object>, ApiGate
     public ApiGatewayResponse handleRequest(Map<String, Object> input, Context context) {
         long start = System.nanoTime();
         eventLogger.logEvent(EventType.CERT_REQUEST_RECEIVED);
-        logger.info(input);
         try {
             if (input.containsKey(requestParser.REQUEST_HEADERS)) {
             // Trace headers only they are provided in the input request, else ignore.

--- a/src/main/java/uk/gov/dvsa/PdfGenerator.java
+++ b/src/main/java/uk/gov/dvsa/PdfGenerator.java
@@ -46,7 +46,7 @@ public class PdfGenerator implements RequestHandler<Map<String, Object>, ApiGate
     public ApiGatewayResponse handleRequest(Map<String, Object> input, Context context) {
         long start = System.nanoTime();
         eventLogger.logEvent(EventType.CERT_REQUEST_RECEIVED);
-
+        logger.info(input);
         try {
             if (input.containsKey(requestParser.REQUEST_HEADERS)) {
             // Trace headers only they are provided in the input request, else ignore.

--- a/src/main/java/uk/gov/dvsa/logging/EventLogger.java
+++ b/src/main/java/uk/gov/dvsa/logging/EventLogger.java
@@ -3,9 +3,13 @@ package uk.gov.dvsa.logging;
 import org.apache.logging.log4j.Logger;
 import uk.gov.dvsa.model.mot.CurrentTracingInformation;
 
+import java.text.NumberFormat;
+import java.text.DecimalFormat;
+
 public class EventLogger {
 
     private final Logger logger;
+    private static final NumberFormat formatter = new DecimalFormat("#0.000000");
 
     public EventLogger(Logger logger) {
         this.logger = logger;
@@ -17,15 +21,17 @@ public class EventLogger {
     }
 
     public void logEvent(EventType event, long durationNanos) {
+        String duration = formatter.format(durationNanos / 10e9);
         LogContextWrapper.setEvent(event);
-        LogContextWrapper.setDuration(durationNanos);
+        LogContextWrapper.setDuration(duration);
         logger.info(event.getDescription());
         LogContextWrapper.cleanupDuration();
     }
 
     public void logError(EventType event, long durationNanos, Exception e) {
+        String duration = formatter.format(durationNanos / 10e9);
         LogContextWrapper.setEvent(event);
-        LogContextWrapper.setDuration(durationNanos);
+        LogContextWrapper.setDuration(duration);
         logger.error(e.getMessage(), e);
         LogContextWrapper.cleanupDuration();
     }

--- a/src/main/java/uk/gov/dvsa/logging/EventType.java
+++ b/src/main/java/uk/gov/dvsa/logging/EventType.java
@@ -9,7 +9,6 @@ public enum EventType {
     CERT_PDF_GENERATION("CERT-PDF-GENERATION", "Generating PDF"),
     CERT_PROCESSED_SUCCESSFULLY("CERT-PROCESSED-SUCCESSFULLY", "Certificate processed successfully"),
     CERT_PROCESSED_ERRONEOUSLY("CERT-PROCESSED-ERRONEOUSLY", "Certificate processing error"),
-    CERT_TEMPLATES_COMPILATION_START("CERT_TEMPLATES_COMPILATION_START", "Starting compilation"),
     CERT_TEMPLATES_FROM_CACHE("CERT_TEMPLATES_FROM_CACHE", "Fetching template from cache completed"),
     CERT_TEMPLATES_HANDLEBARS_COMPILE("CERT_TEMPLATES_HANDLEBARS_COMPILE", "Template compile completed"),
     CERT_SERVER_RECEIVE("SR", "Request received, starting the processing"),

--- a/src/main/java/uk/gov/dvsa/logging/LogContextWrapper.java
+++ b/src/main/java/uk/gov/dvsa/logging/LogContextWrapper.java
@@ -2,9 +2,6 @@ package uk.gov.dvsa.logging;
 
 import org.apache.logging.log4j.ThreadContext;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-
 public class LogContextWrapper {
 
     public static final String CONTEXT_EVENT_KEY = "event";
@@ -15,8 +12,6 @@ public class LogContextWrapper {
     private static final String CONTEXT_SPAN_ID_KEY = "spanId";
     private static final String CONTEXT_PARENT_SPAN_ID_KEY = "parentSpanId";
 
-    private static final NumberFormat formatter = new DecimalFormat("#0.000000");
-
     public static void setEvent(EventType event) {
         ThreadContext.put(CONTEXT_EVENT_KEY, event.getName());
     }
@@ -25,9 +20,9 @@ public class LogContextWrapper {
         ThreadContext.remove(CONTEXT_EVENT_KEY);
     }
 
-    public static void setDuration(Long durationNanos) {
-        ThreadContext.put(CONTEXT_DURATION_KEY, formatter.format(durationNanos / 10e9));
-        ThreadContext.put(CONTEXT_FORMATTED_DURATION_KEY, formatter.format(durationNanos / 10e9) + " seconds");
+    public static void setDuration(String duration) {
+        ThreadContext.put(CONTEXT_DURATION_KEY, duration);
+        ThreadContext.put(CONTEXT_FORMATTED_DURATION_KEY, duration + " seconds");
     }
 
     public static void cleanupDuration() {

--- a/src/main/java/uk/gov/dvsa/logging/LoggingExecutor.java
+++ b/src/main/java/uk/gov/dvsa/logging/LoggingExecutor.java
@@ -15,6 +15,7 @@ public class LoggingExecutor {
 
     public <T> T timed(Supplier<T> operation, EventType event) {
         long start = System.nanoTime();
+        logEvent(event);
         try {
             T result = operation.get();
             logEvent(event, "Done in {} nanoseconds", start);
@@ -31,5 +32,10 @@ public class LoggingExecutor {
         LogContextWrapper.setDuration(duration);
         logger.info(message, duration);
         LogContextWrapper.cleanupDuration();
+    }
+
+    private void logEvent(EventType event) {
+        LogContextWrapper.setEvent(event);
+        logger.info(event.getDescription());
     }
 }

--- a/src/main/java/uk/gov/dvsa/logging/LoggingExecutor.java
+++ b/src/main/java/uk/gov/dvsa/logging/LoggingExecutor.java
@@ -3,10 +3,13 @@ package uk.gov.dvsa.logging;
 import org.apache.logging.log4j.Logger;
 
 import java.util.function.Supplier;
+import java.text.NumberFormat;
+import java.text.DecimalFormat;
 
 public class LoggingExecutor {
 
     private final Logger logger;
+    private static final NumberFormat formatter = new DecimalFormat("#0.000000");
 
     public LoggingExecutor(Logger logger)
     {
@@ -18,16 +21,16 @@ public class LoggingExecutor {
         logEvent(event);
         try {
             T result = operation.get();
-            logEvent(event, "Done in {} nanoseconds", start);
+            logEvent(event, "Done in {} seconds", start);
             return result;
         } catch (Exception e) {
-            logEvent(event, "Failed after {} nanoseconds", start);
+            logEvent(event, "Failed after {} seconds", start);
             throw e;
         }
     }
 
     private void logEvent(EventType event, String message, long start) {
-        long duration = System.nanoTime() - start;
+        String duration = formatter.format((System.nanoTime() - start) / 10e9);;
         LogContextWrapper.setEvent(event);
         LogContextWrapper.setDuration(duration);
         logger.info(message, duration);

--- a/src/main/java/uk/gov/dvsa/service/HtmlGenerator.java
+++ b/src/main/java/uk/gov/dvsa/service/HtmlGenerator.java
@@ -34,12 +34,10 @@ public class HtmlGenerator {
     }
 
     public List<String> generate(Document context) {
-        eventLogger.logEvent(EventType.CERT_TEMPLATES_COMPILATION);
         List<Template> templates = executor.timed(
             () -> getTemplates(context.getDocumentName()),
             EventType.CERT_TEMPLATES_COMPILATION
         );
-        eventLogger.logEvent(EventType.CERT_HTML_GENERATION);
         return executor.timed(
             () -> processTemplates(context, templates),
             EventType.CERT_HTML_GENERATION

--- a/src/main/java/uk/gov/dvsa/service/HtmlGenerator.java
+++ b/src/main/java/uk/gov/dvsa/service/HtmlGenerator.java
@@ -34,21 +34,23 @@ public class HtmlGenerator {
     }
 
     public List<String> generate(Document context) {
+        eventLogger.logEvent(EventType.CERT_TEMPLATES_COMPILATION);
         List<Template> templates = executor.timed(
             () -> getTemplates(context.getDocumentName()),
             EventType.CERT_TEMPLATES_COMPILATION
         );
-        List<String> htmlDocuments = executor.timed(
+        eventLogger.logEvent(EventType.CERT_HTML_GENERATION);
+        return executor.timed(
             () -> processTemplates(context, templates),
             EventType.CERT_HTML_GENERATION
         );
-        return htmlDocuments;
     }
 
     private List<Template> getTemplates(String documentName) {
         List<Template> templates = new ArrayList<>();
         String[] templateNames = DocumentsConfig.fromDocumentName(documentName).getTemplateNames();
         for (String templateName: templateNames) {
+            logger.info("Compiling {} template", templateName);
             templates.add(compileTemplate(templateName));
         }
         return templates;

--- a/src/main/java/uk/gov/dvsa/service/RequestParser.java
+++ b/src/main/java/uk/gov/dvsa/service/RequestParser.java
@@ -28,7 +28,6 @@ public class RequestParser {
     public static final String REQUEST_TRACE_ID_HEADER = "x-b3-traceid";
     public static final String REQUEST_SPAN_ID_HEADER = "x-b3-spanid";
     public static final String REQUEST_PARENT_SPAN_ID_HEADER = "x-b3-parentspanid";
-    public static final String INVOKING_LAMBDA_NAME = "FunctionName";
 
     private static final Logger logger = LogManager.getLogger(RequestParser.class);
 
@@ -67,8 +66,6 @@ public class RequestParser {
     }
 
     private static String readDocumentName(Map<String, Object> input) {
-        logger.info("Received invocation from lambda: {}", input.get(INVOKING_LAMBDA_NAME));
-
         if (!input.containsKey(PATH_PARAMETERS)) {
             throw new HttpException.BadRequestException("Required lambda parameter " + PATH_PARAMETERS + " not found");
         }

--- a/src/main/java/uk/gov/dvsa/service/RequestParser.java
+++ b/src/main/java/uk/gov/dvsa/service/RequestParser.java
@@ -7,7 +7,6 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.dvsa.exception.HttpException;
 import uk.gov.dvsa.logging.EventType;
 import uk.gov.dvsa.logging.LoggingExecutor;
-import uk.gov.dvsa.logging.EventLogger;
 import uk.gov.dvsa.model.Document;
 import uk.gov.dvsa.model.mot.enums.DocumentsConfig;
 
@@ -34,7 +33,6 @@ public class RequestParser {
     private static final Logger logger = LogManager.getLogger(RequestParser.class);
 
     private final LoggingExecutor executor = new LoggingExecutor(logger);
-    private final EventLogger eventLogger = new EventLogger(logger);
 
     static {
         HashMap<String, Class<? extends Document>> documentsMap = new HashMap<>();
@@ -48,7 +46,6 @@ public class RequestParser {
     }
 
     public Document parseRequest(Map<String, Object> input) {
-        eventLogger.logEvent(EventType.CERT_REQUEST_PARSING);
         return executor.timed(() -> parse(input), EventType.CERT_REQUEST_PARSING);
     }
 
@@ -103,7 +100,6 @@ public class RequestParser {
         }
         return documentPath;
     }
-
 
     private static String readRequestBody(Map<String, Object> input) {
         if (!input.containsKey(REQUEST_BODY)) {


### PR DESCRIPTION
## Description
Increased verbosity of logs produced by doc-gen service to help triage issues in production, improvements include:
- Logging of the document name/type requested
- Made more sense of what `Done in x nanoseconds` is relating to.
- Changed units of `Done in x nanoseconds` to `seconds`

Related issue: [CB2-6442](https://dvsa.atlassian.net/browse/CB2-6442)

[ANNUAL_CERT](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2461/DVSA_20CVS_20Backend_20Automation/)
[EXPIRY_DATES](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2464/DVSA_20CVS_20Backend_20Automation/)
[FULL](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2462/DVSA_20CVS_20Backend_20Automation/) - [Failure reruns](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2466/DVSA_20CVS_20Backend_20Automation/)

### Previously:
![image](https://user-images.githubusercontent.com/92087051/199027263-8ae71a8b-f606-4015-864f-ff1e0a53d2fa.png)

### Now:
![image](https://user-images.githubusercontent.com/92087051/199045594-66b03bad-982c-4372-8985-8ea291e722c1.png)