### PR TITLE
CB2-6766 Replacement certificates

### DIFF
--- a/src/main/resources/views/CommercialVehicles/VTG30.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG30.hbs
@@ -83,6 +83,9 @@
         <div class="header">
             <div class="header__left">
                 <h1 class="header__title">
+                    {{#if reissue}}
+                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    {{/if}}
                     Refusal of MOT test certificate
                 </h1>
                 <!-- heading-info -->
@@ -98,9 +101,6 @@
                         Vehicle identification number
                         </span>
                         </span>
-                        {{#if reissue}}
-                        <span class="heading-info__title-message margin-left-50">{{reissue.reason}}</span>
-                        {{/if}}
                     </h2>
                      <span class="heading-info__content" id="vin">
                          {{failData.rawVin}}
@@ -341,6 +341,14 @@
                      </span>
                 </div>
 
+                {{#if reissue}}
+                <div class="util-avoid-page-break-inside" id="reissueInfo">
+                    <p class="test-information__message">
+                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                    </p>
+                </div>
+                {{/if}}
+
                 <div class="util-avoid-page-break-inside">
                     <p class="test-information__message">
                         For a retest, you must get the defects fixed and arrange to take the
@@ -364,9 +372,6 @@
                         Find out about the vehicle’s MOT history at <a class="test-information__message-link"
                                                                             href="www.gov.uk/check-mot-history">www.gov.uk/check-mot-history</a>
                     </p>
-                    {{#if reissue}}
-                        <p class="test-information__message">Replacement certificate issued by {{reissue.issuer}} on {{reissue.date}}</p>
-                    {{/if}}
                 </div>
             </div>
         </div>

--- a/src/main/resources/views/CommercialVehicles/fail.hbs
+++ b/src/main/resources/views/CommercialVehicles/fail.hbs
@@ -83,6 +83,9 @@
         <div class="header">
             <div class="header__left">
                 <h1 class="header__title">
+                    {{#if reissue}}
+                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    {{/if}}
                     Refusal of MOT test certificate
                 </h1>
                 <!-- heading-info -->
@@ -98,9 +101,6 @@
                         Vehicle identification number
                         </span>
                         </span>
-                        {{#if reissue}}
-                        <span class="heading-info__title-message margin-left-50">{{reissue.reason}}</span>
-                        {{/if}}
                     </h2>
                      <span class="heading-info__content" id="vin">
                          {{failData.rawVin}}
@@ -318,6 +318,14 @@
                      </span>
                 </div>
 
+                {{#if reissue}}
+                <div class="util-avoid-page-break-inside" id="reissueInfo">
+                    <p class="test-information__message">
+                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                    </p>
+                </div>
+                {{/if}}
+
                 <div class="util-avoid-page-break-inside">
                     <p class="test-information__message">
                         For a retest, you must get the defects fixed and arrange to take the
@@ -342,9 +350,6 @@
                                                                                      href="www.gov.uk/mot-reminder">www.gov.uk/mot-reminder</a>
                         or by telephone on 0300 1239000.
                     </p>
-                    {{#if reissue}}
-                        <p class="test-information__message">Replacement certificate issued by {{reissue.issuer}} on {{reissue.date}}</p>
-                    {{/if}}
                 </div>
             </div>
         </div>

--- a/src/main/resources/views/CommercialVehicles/pass.hbs
+++ b/src/main/resources/views/CommercialVehicles/pass.hbs
@@ -375,15 +375,6 @@
                          {{data.testNumber}}
                      </span>
                 </div>
-
-                {{#if reissue}}
-                <div class="util-avoid-page-break-inside" id="reissueInfo">
-                    <p class="test-information__message">
-                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
-                    </p>
-                </div>
-                {{/if}}
-
                 <!-- /heading-info -->
                 <div class="util-avoid-page-break-inside">
                     <div class="seat-belt-information__two-columns">
@@ -399,6 +390,13 @@
                         </div>
                     </div>
                 </div>
+                {{#if reissue}}
+                <div class="util-avoid-page-break-inside" id="reissueInfo">
+                    <p class="test-information__message">
+                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                    </p>
+                </div>
+                {{/if}}
                 <div class="util-avoid-page-break-inside">
                     <p class="test-information__message">
                         Check that this document is genuine by visiting <a class="test-information__message-link"

--- a/src/main/resources/views/CommercialVehicles/pass.hbs
+++ b/src/main/resources/views/CommercialVehicles/pass.hbs
@@ -83,6 +83,9 @@
         <div class="header">
             <div class="header__left">
                 <h1 class="header__title">
+                    {{#if reissue}}
+                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    {{/if}}
                     MOT test certificate ({{testType}})
                 </h1>
                 <!-- heading-info -->
@@ -98,9 +101,6 @@
                         Vehicle identification number
                         </span>
                         </span>
-                        {{#if reissue}}
-                        <span class="heading-info__title-message margin-left-50">{{reissue.reason}}</span>
-                        {{/if}}
                     </h2>
                      <span class="heading-info__content" id="vin">
                          {{data.rawVin}}
@@ -375,6 +375,15 @@
                          {{data.testNumber}}
                      </span>
                 </div>
+
+                {{#if reissue}}
+                <div class="util-avoid-page-break-inside" id="reissueInfo">
+                    <p class="test-information__message">
+                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                    </p>
+                </div>
+                {{/if}}
+
                 <!-- /heading-info -->
                 <div class="util-avoid-page-break-inside">
                     <div class="seat-belt-information__two-columns">
@@ -405,9 +414,6 @@
                                                                                      href="www.gov.uk/mot-reminder">www.gov.uk/mot-reminder</a>
                         or by telephone on 0300 1239000.
                     </p>
-                    {{#if reissue}}
-                        <p class="test-information__message">Replacement certificate issued by {{reissue.issuer}} on {{reissue.date}}</p>
-                    {{/if}}
                 </div>
             </div>
         </div>

--- a/src/main/resources/views/CommercialVehicles/passNoSeatbeltFields.hbs
+++ b/src/main/resources/views/CommercialVehicles/passNoSeatbeltFields.hbs
@@ -83,6 +83,9 @@
         <div class="header">
             <div class="header__left">
                 <h1 class="header__title">
+                    {{#if reissue}}
+                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    {{/if}}
                     MOT test certificate ({{testType}})
                 </h1>
                 <!-- heading-info -->
@@ -98,9 +101,6 @@
                         Vehicle identification number
                         </span>
                         </span>
-                        {{#if reissue}}
-                        <span class="heading-info__title-message margin-left-50">{{reissue.reason}}</span>
-                        {{/if}}
                     </h2>
                      <span class="heading-info__content" id="vin">
                          {{data.rawVin}}
@@ -398,6 +398,13 @@
                          {{data.testNumber}}
                      </span>
                 </div>
+                {{#if reissue}}
+                <div class="util-avoid-page-break-inside" id="reissueInfo">
+                    <p class="test-information__message">
+                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                    </p>
+                </div>
+                {{/if}}
                 <!-- /heading-info -->
                 <div class="util-avoid-page-break-inside">
                     <p class="test-information__message">
@@ -414,9 +421,6 @@
                                                                                      href="www.gov.uk/mot-reminder">www.gov.uk/mot-reminder</a>
                         or by telephone on 0300 1239000.
                     </p>
-                    {{#if reissue}}
-                        <p class="test-information__message">Replacement certificate issued by {{reissue.issuer}} on {{reissue.date}}</p>
-                    {{/if}}
                 </div>
             </div>
         </div>

--- a/src/test/java/htmlverification/service/CvsCertificateTestDataProvider.java
+++ b/src/test/java/htmlverification/service/CvsCertificateTestDataProvider.java
@@ -11,7 +11,6 @@ import uk.gov.dvsa.model.mot.enums.CertificateTypes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 public class CvsCertificateTestDataProvider {
@@ -39,6 +38,14 @@ public class CvsCertificateTestDataProvider {
 
         CvsMotCertificateData data = document.getData();
         data.setOdometerHistoryList(null);
+
+        return document;
+    }
+
+    public static VTP20 getReplacementVtp20() {
+        VTP20 document = getVtp20();
+
+        document.setReissue(generateReissuer());
 
         return document;
     }
@@ -88,8 +95,6 @@ public class CvsCertificateTestDataProvider {
                 .setImageType("png");
 
         vtp20.setSignature(signature);
-        vtp20.setReissue(generateReissuer());
-
 
         return vtp20;
     }
@@ -97,9 +102,17 @@ public class CvsCertificateTestDataProvider {
     private static Reissue generateReissuer() {
         Reissue reissue = new Reissue();
         reissue.setIssuer("Joe");
-        reissue.setReason("REPLACEMENT");
+        reissue.setReason("Replacement");
         reissue.setDate("12.1.2022");
         return reissue;
+    }
+
+    public static VTP30 getReplacementVtp30() {
+        VTP30 document = getVtp30();
+
+        document.setReissue(generateReissuer());
+
+        return document;
     }
 
     public static VTP30 getVtp30() {
@@ -157,7 +170,6 @@ public class CvsCertificateTestDataProvider {
                 .setImageType("png");
 
         vtp30.setSignature(signature);
-        vtp30.setReissue(generateReissuer());
 
         return vtp30;
     }

--- a/src/test/java/htmlverification/tests/VTP20Test.java
+++ b/src/test/java/htmlverification/tests/VTP20Test.java
@@ -1,6 +1,8 @@
 package htmlverification.tests;
 
 import com.github.jknack.handlebars.Handlebars;
+
+import htmlverification.framework.exception.HtmlElementNotFoundException;
 import htmlverification.framework.page_object.CertificatePageObject;
 import htmlverification.service.CvsCertificateTestDataProvider;
 import org.junit.Before;
@@ -124,6 +126,36 @@ public class VTP20Test {
     public void verifyTitle() {
         String titleText = certificatePageObject.getElement(".header__title").text();
         String expected = "MOT test certificate (" + testCertificate.getTestType() + ")";
+        assertEquals(expected, titleText);
+    }
+    
+    @Test(expected = HtmlElementNotFoundException.class)
+    public void verifyReplacementInfoNotPresent() {
+        certificatePageObject.getElementById("reissueInfo");
+    }
+
+    @Test
+    public void verifyReplacementTitle() {
+        testCertificate = CvsCertificateTestDataProvider.getReplacementVtp20();
+        String certHtml = htmlGenerator.generate(testCertificate).get(0);
+        certificatePageObject = new CertificatePageObject(certHtml);
+
+        String titleText = certificatePageObject.getElement(".header__title").text();
+        String expected = "Replacement MOT test certificate (" + testCertificate.getTestType() + ")";
+        assertEquals(expected, titleText);
+    }
+
+    @Test
+    public void verifyReplacementInfo() {
+        testCertificate = CvsCertificateTestDataProvider.getReplacementVtp20();
+        String certHtml = htmlGenerator.generate(testCertificate).get(0);
+        certificatePageObject = new CertificatePageObject(certHtml);
+
+        String titleText = certificatePageObject.getElementById("reissueInfo").text();
+        String expected = String.format("%s certificate issued by %s on %s",
+            testCertificate.getReissue().getReason(),
+            testCertificate.getReissue().getIssuer(),
+            testCertificate.getReissue().getDate());
         assertEquals(expected, titleText);
     }
 

--- a/src/test/java/htmlverification/tests/VTP30Test.java
+++ b/src/test/java/htmlverification/tests/VTP30Test.java
@@ -1,6 +1,8 @@
 package htmlverification.tests;
 
 import com.github.jknack.handlebars.Handlebars;
+
+import htmlverification.framework.exception.HtmlElementNotFoundException;
 import htmlverification.framework.page_object.CertificatePageObject;
 import htmlverification.service.CvsCertificateTestDataProvider;
 import org.junit.Before;
@@ -126,6 +128,36 @@ public class VTP30Test {
     public void verifyTitle() {
         String titleText = certificatePageObject.getElement(".header__title").text();
         String expected = "Refusal of MOT test certificate";
+        assertEquals(expected, titleText);
+    }
+    
+    @Test(expected = HtmlElementNotFoundException.class)
+    public void verifyReplacementInfoNotPresent() {
+        certificatePageObject.getElementById("reissueInfo");
+    }
+
+    @Test
+    public void verifyReplacementTitle() {
+        testCertificate = CvsCertificateTestDataProvider.getReplacementVtp30();
+        String certHtml = htmlGenerator.generate(testCertificate).get(0);
+        certificatePageObject = new CertificatePageObject(certHtml);
+
+        String titleText = certificatePageObject.getElement(".header__title").text();
+        String expected = "Replacement Refusal of MOT test certificate";
+        assertEquals(expected, titleText);
+    }
+
+    @Test
+    public void verifyReplacementInfo() {
+        testCertificate = CvsCertificateTestDataProvider.getReplacementVtp30();
+        String certHtml = htmlGenerator.generate(testCertificate).get(0);
+        certificatePageObject = new CertificatePageObject(certHtml);
+
+        String titleText = certificatePageObject.getElementById("reissueInfo").text();
+        String expected = String.format("%s certificate issued by %s on %s",
+            testCertificate.getReissue().getReason(),
+            testCertificate.getReissue().getIssuer(),
+            testCertificate.getReissue().getDate());
         assertEquals(expected, titleText);
     }
 


### PR DESCRIPTION
## Description

Move the replacement specific text on the certificate. It was found that the original details on [CB2-6766](https://dvsa.atlassian.net/browse/CB2-6766) were not correct and a new template provided.

## Evidence of Completion
Before:
![image](https://user-images.githubusercontent.com/13391709/209154028-2dae19f2-0c0a-41d2-8e13-08ce0530d64a.png)
After:
![image](https://user-images.githubusercontent.com/13391709/209153221-34b00425-869a-4c4f-a602-c9c98ae37b97.png)
