### PR TITLE
fix(cb2-7619): fix reason for creation on plates

### DIFF
--- a/src/main/java/uk/gov/dvsa/service/HtmlGenerator.java
+++ b/src/main/java/uk/gov/dvsa/service/HtmlGenerator.java
@@ -2,6 +2,8 @@ package uk.gov.dvsa.service;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.helper.ConditionalHelpers;
+
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,6 +40,9 @@ public class HtmlGenerator {
         Handlebars handlebarsWithHelpers;
         handlebarsWithHelpers = registerTabulatorHelper(handlebars);
         handlebarsWithHelpers = registerIsoDateFormatHelper(handlebars);
+        handlebarsWithHelpers = registerEqualsHelper(handlebars);
+        handlebarsWithHelpers = registerNotEqualsHelper(handlebars);
+        handlebarsWithHelpers = registerOrHelper(handlebars);
         this.handlebars = handlebarsWithHelpers;
     }
 
@@ -109,6 +114,18 @@ public class HtmlGenerator {
                 return context;
             }
         });
+    }
+
+    private Handlebars registerEqualsHelper(Handlebars handlebars) {
+        return handlebars.registerHelper("eq", ConditionalHelpers.eq);
+    }
+
+    private Handlebars registerNotEqualsHelper(Handlebars handlebars) {
+        return handlebars.registerHelper("neq", ConditionalHelpers.neq);
+    }
+
+    private Handlebars registerOrHelper(Handlebars handlebars) {
+        return handlebars.registerHelper("or", ConditionalHelpers.or);
     }
 
     private List<String> processTemplates(Document context, List<Template> templates) {

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -620,7 +620,7 @@
                 <div class="bottom_gray_div">
                     <div class="inline_elem">
                         <div class="inline_elem_child empty_div_before_tyre_use">
-                            {{#if or((eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
+                            {{#if (or (eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
                                 <p>
                                     Replacement
                                 </p>
@@ -1013,7 +1013,7 @@
                                     GREAT BRITAIN
                                 </p>
                             </div>
-                            {{#if or((eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
+                            {{#if (or (eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
                                 <div class="centered_title reissue_department_box ">
                                     Replacement
                                 </div>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -620,11 +620,11 @@
                 <div class="bottom_gray_div">
                     <div class="inline_elem">
                         <div class="inline_elem_child empty_div_before_tyre_use">
-                        {{#if reissue.reason}}
-                            <p>
-                                {{reissue.reason}}
-                            </p>
-                         {{/if}}
+                            {{#if (eq reissue.reason "Free replacement") || (eq reissue.reason "Replacement")}}
+                                <p>
+                                    Replacement
+                                </p>
+                            {{/if}}
                         </div>
                         <div class="inline_elem_child tyre_use">
                             <p>
@@ -1013,11 +1013,11 @@
                                     GREAT BRITAIN
                                 </p>
                             </div>
-                            {{#if reissue.reason}}
-                            <div class="centered_title reissue_department_box">
-                                <p>{{reissue.reason}}</p>
-                            </div>
-                             {{/if}}
+                            {{#if (eq reissue.reason "Free replacement") || (eq reissue.reason "Replacement")}}
+                                <div class="centered_title reissue_department_box ">
+                                    Replacement
+                                </div>
+                            {{/if}}
                         </div>
                     </td>
                 </tr>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -620,7 +620,7 @@
                 <div class="bottom_gray_div">
                     <div class="inline_elem">
                         <div class="inline_elem_child empty_div_before_tyre_use">
-                            {{#if (eq reissue.reason "Free replacement") || (eq reissue.reason "Replacement")}}
+                            {{#if or((eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
                                 <p>
                                     Replacement
                                 </p>
@@ -1013,7 +1013,7 @@
                                     GREAT BRITAIN
                                 </p>
                             </div>
-                            {{#if (eq reissue.reason "Free replacement") || (eq reissue.reason "Replacement")}}
+                            {{#if or((eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
                                 <div class="centered_title reissue_department_box ">
                                     Replacement
                                 </div>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
@@ -546,7 +546,7 @@
                 <div class="bottom_gray_div">
                     <div class="inline_elem">
                         <div class="inline_elem_child empty_div_before_tyre_use">
-                        {{#if or((eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
+                        {{#if (or (eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
                             <p>
                                 Replacement
                             </p>
@@ -889,7 +889,7 @@
                                     GREAT BRITAIN
                                 </p>
                             </div>
-                            {{#if or((eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
+                            {{#if (or (eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
                                 <div class="centered_title reissue_department_box ">
                                     Replacement
                                 </div>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
@@ -546,7 +546,7 @@
                 <div class="bottom_gray_div">
                     <div class="inline_elem">
                         <div class="inline_elem_child empty_div_before_tyre_use">
-                        {{#if (eq reissue.reason "Free replacement") || (eq reissue.reason "Replacement")}}
+                        {{#if or((eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
                             <p>
                                 Replacement
                             </p>
@@ -889,7 +889,7 @@
                                     GREAT BRITAIN
                                 </p>
                             </div>
-                            {{#if (eq reissue.reason "Free replacement") || (eq reissue.reason "Replacement")}}
+                            {{#if or((eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
                                 <div class="centered_title reissue_department_box ">
                                     Replacement
                                 </div>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
@@ -546,9 +546,9 @@
                 <div class="bottom_gray_div">
                     <div class="inline_elem">
                         <div class="inline_elem_child empty_div_before_tyre_use">
-                        {{#if reissue.reason}}
+                        {{#if (eq reissue.reason "Free replacement") || (eq reissue.reason "Replacement")}}
                             <p>
-                                {{reissue.reason}}
+                                Replacement
                             </p>
                          {{/if}}
                         </div>
@@ -889,11 +889,11 @@
                                     GREAT BRITAIN
                                 </p>
                             </div>
-                            {{#if reissue.reason}}
-                            <div class="centered_title reissue_department_box ">
-                                <p>{{reissue.reason}}</p>
-                            </div>
-                             {{/if}}
+                            {{#if (eq reissue.reason "Free replacement") || (eq reissue.reason "Replacement")}}
+                                <div class="centered_title reissue_department_box ">
+                                    Replacement
+                                </div>
+                            {{/if}}
                         </div>
                     </td>
                 </tr>


### PR DESCRIPTION
## Description

The plates were printing the reason for creation no matter what it is, where as in reality there was business logic here, this change fixes that and tidys up the helpers implementation.

Related issue: [https://dvsa.atlassian.net/browse/CB2-7619](7619)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
