### PR TITLE
fix(cb2-7879, cb2-7880, cb2-7890, cb2-7832): vtg6 and vtg7 plates fixes

### DIFF
--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -355,7 +355,7 @@ white-space: nowrap;
 
 .coupling_foremost {
 text-align: center;
-width:115px;
+width:110px;
 font-size:10px;
 }
 
@@ -364,7 +364,7 @@ font-size:10px;
 }
 
 .coupling_max_min {
-width: 57px;
+width: 50px;
 font-size: 8px;
 }
 

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -806,3 +806,8 @@ padding-bottom: 10px;
 .w-30 {
 width: 30px
 }
+
+.secondPage > p, .secondPage > ol {
+margin-top: .25em;
+margin-bottom: 0.25em;
+}

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -72,7 +72,7 @@
                 </tr>
                 <tr>
                     <td colspan="13" class="no_border_top align_top">
-                        <p class="tyre_approval">Tyre Approval No. &nbsp; <strong
+                        <p class="tyre_approval">Type Approval No. &nbsp; <strong
                                 id="approvalTypeNumber">{{plateData.approvalTypeNumber}}</strong></p>
                     </td>
                 </tr>
@@ -759,7 +759,7 @@
                 </tr>
                 <tr>
                     <td colspan="13" class="no_border_top align_top">
-                        <p class="tyre_approval">Tyre Approval No. &nbsp; <strong
+                        <p class="tyre_approval">Type Approval No. &nbsp; <strong
                                 id="approvalTypeNumber">{{plateData.approvalTypeNumber}}</strong></p>
                     </td>
                 </tr>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -1336,7 +1336,11 @@
                 <li>If the last letter in the function box is &lsquo;R&rsquo; road friendly suspension is fitted</li>
                 <li>All weight shown are subject to the fitting of correct tyres</li>
                 <li>The weight applies to combined transport operations.</li>
-                <li style="list-style-type: none;">(6-8 deleted)</li>
+                <li>This dimension only applies to drawn vehicles of trailers and semi-trailers</li>
+                <li>This dimension only applies to trailer and semi-trailers</li>
+                <li>Where there is no weight shown in the EEC maximum permitted weights column this is because there is no
+                    EEC standard relating to that weight.
+                </li>
             </ol>
             <p><strong>NOTIFIABLE ALTERATIONS </strong></p>
             <ol start="9">

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -12,699 +12,699 @@
 
 <body>
 <div class="separatePage">
-<table>
-<td class='table-half'>
-    <table class="vtg7">
-        <tbody>
-        <tr>
-            <td colspan="4" rowspan="2" class="logo">
-                <img src="{{root}}/assets/images/dvsa-crest-1.1.png" alt="DVSA" width="110"/>
-            </td>
-            <td colspan="4" rowspan="2" class="plating_certificate">
-                <p class="department_for_transport">
-                    <strong>Department For Transport</strong></p>
-                <p class="road_traffic">
-                    ROAD TRAFFIC ACT 1988 SECTIONS 41, 49, 57 &amp; 58 EXAMINATION OF GOODS VEHICLE
-                </p>
-                <p class="proof_of_compliance">
-                    This is issued as proof of compliance with the weights and dimensions directive 85/3/EEC
-                </p>
-                <div class="inline_elem">
-                    <div class="inline_elem_child">
-                        <p class="plating_cert">
-                            Plating Certificate
+    <table>
+        <td class='table-half'>
+            <table class="vtg7">
+                <tbody>
+                <tr>
+                    <td colspan="4" rowspan="2" class="logo">
+                        <img src="{{root}}/assets/images/dvsa-crest-1.1.png" alt="DVSA" width="110"/>
+                    </td>
+                    <td colspan="4" rowspan="2" class="plating_certificate">
+                        <p class="department_for_transport">
+                            <strong>Department For Transport</strong></p>
+                        <p class="road_traffic">
+                            ROAD TRAFFIC ACT 1988 SECTIONS 41, 49, 57 &amp; 58 EXAMINATION OF GOODS VEHICLE
                         </p>
-                    </div>
-                    <div class="inline_elem_child vtg7a">
-                        <p>
-                            VTG7A
+                        <p class="proof_of_compliance">
+                            This is issued as proof of compliance with the weights and dimensions directive 85/3/EEC
                         </p>
-                        <p>
-                            Rev 2010
-                        </p>
-                    </div>
-                </div>
-            </td>
-            <td colspan="5" class="plating_certificate">
-                <p class="serial_dtp"> Serial No.&nbsp;</p>
-                <p class="serial_value" id="plateSerialNumber">{{plateData.plateSerialNumber}}</p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="6" class="dtp_data">
-                <p class="serial_dtp"> DTp Ref. No.&nbsp;</p>
-                <p class="dtp_value" id="dtpNumber">{{plateData.dtpNumber}}</p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="3" class="no_border_top align_top">
-                <p class="vehicle_identifier">Reg./ Ident Mark</p>
-                <p class="vehicle_identifier_data" id="primaryVrm">{{plateData.primaryVrm}}</p>
-            </td>
-            <td colspan="5" class="no_border_left_top align_top">
-                <p class="vehicle_identifier">Vehicle Identification No.</p>
-                <p class="vehicle_identifier_data" id="vin">{{plateData.vin}}</p>
-            </td>
-            <td colspan="5" class="no_border_left_top align_top">
-                <p class="vehicle_identifier">Variant</p>
-                <p class="vehicle_identifier_data" id="variantNumber">{{plateData.variantNumber}}</p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="13" class="no_border_top align_top">
-                <p class="tyre_approval">Tyre Approval No. &nbsp; <strong
-                        id="approvalTypeNumber">{{plateData.approvalTypeNumber}}</strong></p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="8" class="no_border_top align_top manufacturer">
-                <div class="inline_elem">
-                    <div class="inline_elem_child manufacturer_model_container">
-                        <p>
-                            <span>Manufacturer/</span>
-                        </p>
-                        <p>
-                            <span>Model</span>
-                        </p>
-                    </div>
-                    <div class="inline_elem_child">
-                        <p class="make_model_container">
-                            <span class="manufacturer_data" id="make-model">{{plateData.make}}/{{plateData.model}}</span>
-                        </p>
-                    </div>
-                </div>
-            </td>
-            <td colspan="5" class="no_border_left_top align_top speed_limiter">
-                <p>
-                    <span>Speed</span>
-                </p>
-                <p>
-                    <span>Limiter</span>
-                    <span class="speed_limiter_data" id="speedLimiterMrk">{{plateData.speedLimiterMrk}}</span>
-                </p>
-                <p>
-                    <span>Exempt</span>
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="4" class="no_border_top function_code">
-                <div class="inline_elem_child">
-                    <p>
-                        <span>Function</span>
-                    </p>
-                    <p>
-                        <span>(See note 3)</span>
-                    </p>
-                </div>
-                <div class="inline_elem_child align_middle">
-                    <span class="function_code_data" id="functionCode">{{plateData.functionCode}}</span>
-                </div>
-            </td>
-            <td colspan="4" class="no_border_left_top regn_date">
-                <div class="inline_elem_child">
-                    <p>
-                        <span>Year of Original</span>
-                    </p>
-                    <p> Registration </p>
-                </div>
-                <div class="inline_elem_child align_middle">
-                    <span class="regn_date_data" id="regnDate">{{formatIsoDate plateData.regnDate}}</span>
-                </div>
-            </td>
-            <td colspan="5" class="no_border_left_top manufacture_year">
-                <div class="inline_elem_child">
-                    <p>
-                        <span>Year of</span>
-                    </p>
-                    <p>
-                        <span>Manufacture</span>
-                    </p>
-                </div>
-                <div class="inline_elem_child align_middle">
-                    <span class="manufacture_year_data" id="manufactureYear">{{plateData.manufactureYear}}</span>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" rowspan="2" class="weights_description width_25">
-                <div class="inline_elem description_of_weights">
-                    <span class="inline_elem_child weight_numbering"> (1) </span>
-                    <span class="inline_elem_child weight_title">Description of Weights Applicable to vehicle</span>
-                </div>
-            </td>
-            <td colspan="2" rowspan="2" class="no_border_left_top align_top width_25">
-                <div class="inline_elem">
-                    <span class="inline_elem_child weight_numbering"> (2) </span>
-                    <span class="inline_elem_child weight_title">Weights not to be exceeded in Gt. Britain</span>
-                </div>
-            </td>
-            <td rowspan="2" class="no_border_left_top align_top width_25">
-                <div class="inline_elem">
-                    <span class="inline_elem_child weight_numbering"> (3) </span>
-                    <span class="inline_elem_child weight_title">EEC Maximum permitted weights</span>
-                </div>
-                <p class="weight_notes">(See note 8)</p>
-            </td>
-            <td colspan="2" rowspan="2" class="no_border_left_top align_top width_25">
-                <div class="inline_elem">
-                    <span class="inline_elem_child weight_numbering"> (4) </span>
-                    <span class="inline_elem_child weight_title">Design Weights</span>
-                </div>
-                <p class="weight_notes">(if higher than shown in column 2)</p>
-            </td>
-            <td colspan="2" class="no_border_left_top length_width">
-                <p class="centered_data"><strong>Length</strong></p>
-            </td>
-            <td colspan="4" class="no_border_left_top length_width">
-                <p class="centered_data"><strong>Width</strong></p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="dimensionLength">{{plateData.dimensionLength}}</strong>
-                </p>
-            </td>
-            <td colspan="4" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="dimensionWidth">{{plateData.dimensionWidth}}</strong>
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_top align_middle">
-                <p class="centered_title">
-                    <strong class="weight_titles">Gross Weight</strong>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weight_notes">(See notes 1 &amp; 4)</span>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="grossGbWeight">{{plateData.grossGbWeight}}</strong>
-                </p>
-            </td>
-            <td class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="grossEecWeight">{{plateData.grossEecWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="grossDesignWeight">{{plateData.grossDesignWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <div class="coupling_foremost">
-                    <span>a. Coupling centre to vehicle foremost part (See note 6)</span>
-                </div>
-            </td>
-            <td colspan="2" class="no_border_left_top align_top">
-                <div class="centered_title coupling_max_min">
-                    <strong>Max</strong>
-                    <p class="centered_data">
-                        <strong id="frontVehicleTo5thWheelCouplingMax">{{plateData.frontVehicleTo5thWheelCouplingMax}}</strong>
-                    </p>
-                </div>
-            </td>
-            <td colspan="2" class="no_border_left_top align_top">
-                <div class="centered_title coupling_max_min">
-                    <strong>Min</strong>
-                    <p class="centered_data">
-                        <strong id="frontVehicleTo5thWheelCouplingMin">{{plateData.frontVehicleTo5thWheelCouplingMin}}</strong>
-                    </p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_top align_middle">
-                <p class="centered_title">
-                    <strong class="weight_titles">Train Weight</strong>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weight_notes">(See note 2)</span>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="trainGbWeight">{{plateData.trainGbWeight}}</strong>
-                </p>
-            </td>
-            <td class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="trainEecWeight">{{plateData.trainEecWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="trainDesignWeight">{{plateData.trainDesignWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <div class="coupling_rearmost">
-                    <span>b. Coupling centre to vehicle rearmost part (See note 7)</span>
-                </div>
-            </td>
-            <td colspan="2" class="no_border_left_top align_top">
-                <div class="centered_title coupling_max_min">
-                    <strong>Max</strong>
-                    <p class="centered_data">
-                        <strong id="couplingCenterToRearTrlMax">{{plateData.couplingCenterToRearTrlMax}}</strong>
-                    </p>
-                </div>
-            </td>
-            <td colspan="2" class="no_border_left_top align_top">
-                <div class="centered_title coupling_max_min">
-                    <strong>Min</strong>
-                    <p class="centered_data">
-                        <strong id="couplingCenterToRearTrlMin">{{plateData.couplingCenterToRearTrlMin}}</strong>
-                    </p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_top align_middle">
-                <p class="centered_title">
-                    <strong class="weight_titles">Max. Train Weight</strong>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weight_notes">(See note 5)</span>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="maxTrainGbWeight">{{plateData.maxTrainGbWeight}}</strong>
-                </p>
-            </td>
-            <td class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="maxTrainEecWeight">{{plateData.maxTrainEecWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top gray_box">
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <div>
-                    <p class="centered_title tyres">
-                        <strong class="axle_weight_notes">Tyre size</strong>
-                    </p>
-                    <p class="centered_title tyres">
-                        <span class="axle_weight_notes">(Fitted at time of issue of certificate)</span>
-                    </p>
-                </div>
-            </td>
-            <td colspan="3" class="no_border_left_top align_top">
-                <div>
-                    <p class="ply_load_index"> Ply rating or load index</p>
-                </div>
-            </td>
-            <td class="no_border_left_top align_top">
-                <div class="centered_title">
-                    <p class="fitment_code">*S</p>
-                    <p class="fitment_code">or</p>
-                    <p class="fitment_code">D</p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td rowspan="4" class="no_border_top align_top">
-                <p class="centered_title">
-                    <strong class="axle_weights">Axle</strong>
-                </p>
-                <p class="centered_title">
-                    <strong class="axle_weights">Weights</strong>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">(Axle</span>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">numbered</span>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">from front</span>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">to rear)</span>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">(See note 1)</span>
-                </p>
-            </td>
-            <td class="no_border_left_top">
-                <p class="axle_number"> Axle 1 </p>
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.weights.gbWeight}}
-                    <p class="centered_data">
-                        <strong id="axle1_gbWeight">{{plateData.axles.axle1.weights.gbWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.weights.eecWeight}}
-                    <p class="centered_data">
-                        <strong id="axle1_eecWeight">{{plateData.axles.axle1.weights.eecWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.weights.designWeight}}
-                    <p class="centered_data">
-                        <strong id="axle1_designWeight">{{plateData.axles.axle1.weights.designWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.tyres.tyreSize}}
-                    <p class="centered_data">
-                        <strong id="axle1_tyreSize">{{plateData.axles.axle1.tyres.tyreSize}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="3" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.tyres.plyRating}}
-                    <div class="ply_rating">
-                        <strong id="axle1_plyRating">{{plateData.axles.axle1.tyres.plyRating}}</strong>
-                    </div>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.tyres.fitmentCode}}
-                    <p class="centered_data">
-                        <strong id="axle1_fitmentCode">{{plateData.axles.axle1.tyres.fitmentCode}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-        </tr>
-        <tr>
-            <td class="no_border_left_top axle_data">
-                <p class="axle_number"> Axle 2 </p>
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.weights.gbWeight}}
-                    <p class="centered_data">
-                        <strong id="axle2_gbWeight">{{plateData.axles.axle2.weights.gbWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.weights.eecWeight}}
-                    <p class="centered_data">
-                        <strong id="axle2_eecWeight">{{plateData.axles.axle2.weights.eecWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.weights.designWeight}}
-                    <p class="centered_data">
-                        <strong id="axle2_designWeight">{{plateData.axles.axle2.weights.designWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.tyres.tyreSize}}
-                    <p class="centered_data">
-                        <strong id="axle2_tyreSize">{{plateData.axles.axle2.tyres.tyreSize}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="3" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.tyres.plyRating}}
-                    <div class="ply_rating">
-                        <strong id="axle2_plyRating">{{plateData.axles.axle2.tyres.plyRating}}</strong>
-                    </div>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.tyres.fitmentCode}}
-                    <p class="centered_data">
-                        <strong id="axle2_fitmentCode">{{plateData.axles.axle2.tyres.fitmentCode}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-        </tr>
-        <tr>
-            <td class="no_border_left_top align_middle">
-                <p class="axle_number"> Axle 3 </p>
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.weights.gbWeight}}
-                    <p class="centered_data">
-                        <strong id="axle3_gbWeight">{{plateData.axles.axle3.weights.gbWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.weights.eecWeight}}
-                    <p class="centered_data">
-                        <strong id="axle3_eecWeight">{{plateData.axles.axle3.weights.eecWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.weights.designWeight}}
-                    <p class="centered_data">
-                        <strong id="axle3_designWeight">{{plateData.axles.axle3.weights.designWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.tyres.tyreSize}}
-                    <p class="centered_data">
-                        <strong id="axle3_tyreSize">{{plateData.axles.axle3.tyres.tyreSize}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="3" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.tyres.plyRating}}
-                    <div class="ply_rating">
-                        <strong id="axle3_plyRating">{{plateData.axles.axle3.tyres.plyRating}}</strong>
-                    </div>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.tyres.fitmentCode}}
-                    <p class="centered_data">
-                        <strong id="axle3_fitmentCode">{{plateData.axles.axle3.tyres.fitmentCode}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-        </tr>
-        <tr>
-            <td class="no_border_left_top axle_data">
-                <p class="axle_number">Axle 4</p>
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.weights.gbWeight}}
-                    <p class="centered_data">
-                        <strong id="axle4_gbWeight">{{plateData.axles.axle4.weights.gbWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.weights.eecWeight}}
-                    <p class="centered_data">
-                        <strong id="axle4_eecWeight">{{plateData.axles.axle4.weights.eecWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.weights.designWeight}}
-                    <p class="centered_data">
-                        <strong id="axle4_designWeight">{{plateData.axles.axle4.weights.designWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.tyres.tyreSize}}
-                    <p class="centered_data">
-                        <strong id="axle4_tyreSize">{{plateData.axles.axle4.tyres.tyreSize}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="3" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.tyres.plyRating}}
-                    <div class="ply_rating">
-                        <strong id="axle4_plyRating">{{plateData.axles.axle4.tyres.plyRating}}</strong>
-                    </div>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.tyres.fitmentCode}}
-                    <p class="centered_data">
-                        <strong id="axle4_fitmentCode">{{plateData.axles.axle4.tyres.fitmentCode}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_top max_kingpin">
-                <p class="max_kingpin_title">
-                    <strong>Maximum Kingpin</strong>
-                </p>
-                <p class="max_kingpin_title">
-                    <strong>Load</strong>
-                </p>
-                <p class="max_kingpin_note">
-                    <span>(Semi-Trailers Only)</span>
-                </p>
-            </td>
-            <td colspan="3" class="no_border_left_top align_top gray_box">
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="max_load">
-                    <strong id="maxLoadOnCoupling">{{plateData.maxLoadOnCoupling}}</strong>
-                </p>
-            </td>
-            <td colspan="6" class="no_border_left_top align_top">
-                <p class="max_kingpin_title">
-                    *&rsquo;S&rsquo; indicates single wheels
-                </p>
-                <p class="max_kingpin_title">
-                    &lsquo;D&rsquo; indicates dual wheels
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="13" class="no_border_top align_top gray_box">
-                <div class="bottom_gray_div">
-                    <div class="inline_elem">
-                        <div class="inline_elem_child empty_div_before_tyre_use">
-                            {{#if (or (eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
-                                <p>
-                                    Replacement
+                        <div class="inline_elem">
+                            <div class="inline_elem_child">
+                                <p class="plating_cert">
+                                    Plating Certificate
                                 </p>
-                            {{/if}}
+                            </div>
+                            <div class="inline_elem_child vtg7a">
+                                <p>
+                                    VTG7A
+                                </p>
+                                <p>
+                                    Rev 2010
+                                </p>
+                            </div>
                         </div>
-                        <div class="inline_elem_child tyre_use">
+                    </td>
+                    <td colspan="5" class="plating_certificate">
+                        <p class="serial_dtp"> Serial No.&nbsp;</p>
+                        <p class="serial_value" id="plateSerialNumber">{{plateData.plateSerialNumber}}</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="6" class="dtp_data">
+                        <p class="serial_dtp"> DTp Ref. No.&nbsp;</p>
+                        <p class="dtp_value" id="dtpNumber">{{plateData.dtpNumber}}</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="3" class="no_border_top align_top">
+                        <p class="vehicle_identifier">Reg./ Ident Mark</p>
+                        <p class="vehicle_identifier_data" id="primaryVrm">{{plateData.primaryVrm}}</p>
+                    </td>
+                    <td colspan="5" class="no_border_left_top align_top">
+                        <p class="vehicle_identifier">Vehicle Identification No.</p>
+                        <p class="vehicle_identifier_data" id="vin">{{plateData.vin}}</p>
+                    </td>
+                    <td colspan="5" class="no_border_left_top align_top">
+                        <p class="vehicle_identifier">Variant</p>
+                        <p class="vehicle_identifier_data" id="variantNumber">{{plateData.variantNumber}}</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="13" class="no_border_top align_top">
+                        <p class="tyre_approval">Tyre Approval No. &nbsp; <strong
+                                id="approvalTypeNumber">{{plateData.approvalTypeNumber}}</strong></p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="8" class="no_border_top align_top manufacturer">
+                        <div class="inline_elem">
+                            <div class="inline_elem_child manufacturer_model_container">
+                                <p>
+                                    <span>Manufacturer/</span>
+                                </p>
+                                <p>
+                                    <span>Model</span>
+                                </p>
+                            </div>
+                            <div class="inline_elem_child">
+                                <p class="make_model_container">
+                                    <span class="manufacturer_data" id="make-model">{{plateData.make}}/{{plateData.model}}</span>
+                                </p>
+                            </div>
+                        </div>
+                    </td>
+                    <td colspan="5" class="no_border_left_top align_top speed_limiter">
+                        <p>
+                            <span>Speed</span>
+                        </p>
+                        <p>
+                            <span>Limiter</span>
+                            <span class="speed_limiter_data" id="speedLimiterMrk">{{plateData.speedLimiterMrk}}</span>
+                        </p>
+                        <p>
+                            <span>Exempt</span>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="4" class="no_border_top function_code">
+                        <div class="inline_elem_child">
                             <p>
-                                Tyre use conditions applicable to vehicle (See note 12)
+                                <span>Function</span>
+                            </p>
+                            <p>
+                                <span>(See note 3)</span>
                             </p>
                         </div>
-                        <div class="inline_elem_child tyre_use_data">
-                            <p id="tyreUseCode">
-                                {{plateData.tyreUseCode}}
+                        <div class="inline_elem_child align_middle">
+                            <span class="function_code_data" id="functionCode">{{plateData.functionCode}}</span>
+                        </div>
+                    </td>
+                    <td colspan="4" class="no_border_left_top regn_date">
+                        <div class="inline_elem_child">
+                            <p>
+                                <span>Year of Original</span>
+                            </p>
+                            <p> Registration </p>
+                        </div>
+                        <div class="inline_elem_child align_middle">
+                            <span class="regn_date_data" id="regnDate">{{formatIsoDate plateData.regnDate}}</span>
+                        </div>
+                    </td>
+                    <td colspan="5" class="no_border_left_top manufacture_year">
+                        <div class="inline_elem_child">
+                            <p>
+                                <span>Year of</span>
+                            </p>
+                            <p>
+                                <span>Manufacture</span>
                             </p>
                         </div>
-                    </div>
-                    <div class="notifiable_alt">
-                        <p>NOTIFIABLE ALTERATIONS (Section 51 (1) (d) of the Road Traffic Act 1988)</p>
-                        <p class="notifiable_alt_following">
-                            The following alterations in the vehicle or the equipment must
-                            be notified to the Secretary of State. (See notes 9 to 11)
+                        <div class="inline_elem_child align_middle">
+                            <span class="manufacture_year_data" id="manufactureYear">{{plateData.manufactureYear}}</span>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" rowspan="2" class="weights_description width_25">
+                        <div class="inline_elem description_of_weights">
+                            <span class="inline_elem_child weight_numbering"> (1) </span>
+                            <span class="inline_elem_child weight_title">Description of Weights Applicable to vehicle</span>
+                        </div>
+                    </td>
+                    <td colspan="2" rowspan="2" class="no_border_left_top align_top width_25">
+                        <div class="inline_elem">
+                            <span class="inline_elem_child weight_numbering"> (2) </span>
+                            <span class="inline_elem_child weight_title">Weights not to be exceeded in Gt. Britain</span>
+                        </div>
+                    </td>
+                    <td rowspan="2" class="no_border_left_top align_top width_25">
+                        <div class="inline_elem">
+                            <span class="inline_elem_child weight_numbering"> (3) </span>
+                            <span class="inline_elem_child weight_title">EEC Maximum permitted weights</span>
+                        </div>
+                        <p class="weight_notes">(See note 8)</p>
+                    </td>
+                    <td colspan="2" rowspan="2" class="no_border_left_top align_top width_25">
+                        <div class="inline_elem">
+                            <span class="inline_elem_child weight_numbering"> (4) </span>
+                            <span class="inline_elem_child weight_title">Design Weights</span>
+                        </div>
+                        <p class="weight_notes">(if higher than shown in column 2)</p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top length_width">
+                        <p class="centered_data"><strong>Length</strong></p>
+                    </td>
+                    <td colspan="4" class="no_border_left_top length_width">
+                        <p class="centered_data"><strong>Width</strong></p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="dimensionLength">{{plateData.dimensionLength}}</strong>
                         </p>
-                        <p>(a) &nbsp; An alteration made in the structure or fixed equipment of the vehicle which
-                            carries the carrying capacity or towing capacity of the vehicle;</p>
-                        <p>(b) &nbsp; An alteration, affecting any part of a braking system or the steering system with
-                            which the vehicle is equipped or of the means of the operation of that system; of</p>
-                        <p>(c) &nbsp; Any other alteration made in the structure or fixed equipment of the vehicle which
-                            renders or is likely to render the vehicle unsafe to travel on roads at any weight equal to
-                            any weight shown in column (2) of the plating certificate.</p>
-                    </div>
-                    <div class="inline_elem bottom_details">
-                        <div class="inline_elem_child bottom_left_details">
+                    </td>
+                    <td colspan="4" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="dimensionWidth">{{plateData.dimensionWidth}}</strong>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_top align_middle">
+                        <p class="centered_title">
+                            <strong class="weight_titles">Gross Weight</strong>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weight_notes">(See notes 1 &amp; 4)</span>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="grossGbWeight">{{plateData.grossGbWeight}}</strong>
+                        </p>
+                    </td>
+                    <td class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="grossEecWeight">{{plateData.grossEecWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="grossDesignWeight">{{plateData.grossDesignWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <div class="coupling_foremost">
+                            <span>a. Coupling centre to vehicle foremost part (See note 6)</span>
+                        </div>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Max</strong>
+                            <p class="centered_data">
+                                <strong id="frontVehicleTo5thWheelCouplingMax">{{plateData.frontVehicleTo5thWheelCouplingMax}}</strong>
+                            </p>
+                        </div>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Min</strong>
+                            <p class="centered_data">
+                                <strong id="frontVehicleTo5thWheelCouplingMin">{{plateData.frontVehicleTo5thWheelCouplingMin}}</strong>
+                            </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_top align_middle">
+                        <p class="centered_title">
+                            <strong class="weight_titles">Train Weight</strong>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weight_notes">(See note 2)</span>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="trainGbWeight">{{plateData.trainGbWeight}}</strong>
+                        </p>
+                    </td>
+                    <td class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="trainEecWeight">{{plateData.trainEecWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="trainDesignWeight">{{plateData.trainDesignWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <div class="coupling_rearmost">
+                            <span>b. Coupling centre to vehicle rearmost part (See note 7)</span>
+                        </div>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Max</strong>
+                            <p class="centered_data">
+                                <strong id="couplingCenterToRearTrlMax">{{plateData.couplingCenterToRearTrlMax}}</strong>
+                            </p>
+                        </div>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Min</strong>
+                            <p class="centered_data">
+                                <strong id="couplingCenterToRearTrlMin">{{plateData.couplingCenterToRearTrlMin}}</strong>
+                            </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_top align_middle">
+                        <p class="centered_title">
+                            <strong class="weight_titles">Max. Train Weight</strong>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weight_notes">(See note 5)</span>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="maxTrainGbWeight">{{plateData.maxTrainGbWeight}}</strong>
+                        </p>
+                    </td>
+                    <td class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="maxTrainEecWeight">{{plateData.maxTrainEecWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top gray_box">
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <div>
+                            <p class="centered_title tyres">
+                                <strong class="axle_weight_notes">Tyre size</strong>
+                            </p>
+                            <p class="centered_title tyres">
+                                <span class="axle_weight_notes">(Fitted at time of issue of certificate)</span>
+                            </p>
+                        </div>
+                    </td>
+                    <td colspan="3" class="no_border_left_top align_top">
+                        <div>
+                            <p class="ply_load_index"> Ply rating or load index</p>
+                        </div>
+                    </td>
+                    <td class="no_border_left_top align_top">
+                        <div class="centered_title">
+                            <p class="fitment_code">*S</p>
+                            <p class="fitment_code">or</p>
+                            <p class="fitment_code">D</p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td rowspan="4" class="no_border_top align_top">
+                        <p class="centered_title">
+                            <strong class="axle_weights">Axle</strong>
+                        </p>
+                        <p class="centered_title">
+                            <strong class="axle_weights">Weights</strong>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">(Axle</span>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">numbered</span>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">from front</span>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">to rear)</span>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">(See note 1)</span>
+                        </p>
+                    </td>
+                    <td class="no_border_left_top">
+                        <p class="axle_number"> Axle 1 </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.weights.gbWeight}}
+                            <p class="centered_data">
+                                <strong id="axle1_gbWeight">{{plateData.axles.axle1.weights.gbWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.weights.eecWeight}}
+                            <p class="centered_data">
+                                <strong id="axle1_eecWeight">{{plateData.axles.axle1.weights.eecWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.weights.designWeight}}
+                            <p class="centered_data">
+                                <strong id="axle1_designWeight">{{plateData.axles.axle1.weights.designWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.tyres.tyreSize}}
+                            <p class="centered_data">
+                                <strong id="axle1_tyreSize">{{plateData.axles.axle1.tyres.tyreSize}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="3" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.tyres.plyRating}}
+                            <div class="ply_rating">
+                                <strong id="axle1_plyRating">{{plateData.axles.axle1.tyres.plyRating}}</strong>
+                            </div>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.tyres.fitmentCode}}
+                            <p class="centered_data">
+                                <strong id="axle1_fitmentCode">{{plateData.axles.axle1.tyres.fitmentCode}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="no_border_left_top axle_data">
+                        <p class="axle_number"> Axle 2 </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.weights.gbWeight}}
+                            <p class="centered_data">
+                                <strong id="axle2_gbWeight">{{plateData.axles.axle2.weights.gbWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.weights.eecWeight}}
+                            <p class="centered_data">
+                                <strong id="axle2_eecWeight">{{plateData.axles.axle2.weights.eecWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.weights.designWeight}}
+                            <p class="centered_data">
+                                <strong id="axle2_designWeight">{{plateData.axles.axle2.weights.designWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.tyres.tyreSize}}
+                            <p class="centered_data">
+                                <strong id="axle2_tyreSize">{{plateData.axles.axle2.tyres.tyreSize}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="3" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.tyres.plyRating}}
+                            <div class="ply_rating">
+                                <strong id="axle2_plyRating">{{plateData.axles.axle2.tyres.plyRating}}</strong>
+                            </div>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.tyres.fitmentCode}}
+                            <p class="centered_data">
+                                <strong id="axle2_fitmentCode">{{plateData.axles.axle2.tyres.fitmentCode}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="no_border_left_top align_middle">
+                        <p class="axle_number"> Axle 3 </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.weights.gbWeight}}
+                            <p class="centered_data">
+                                <strong id="axle3_gbWeight">{{plateData.axles.axle3.weights.gbWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.weights.eecWeight}}
+                            <p class="centered_data">
+                                <strong id="axle3_eecWeight">{{plateData.axles.axle3.weights.eecWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.weights.designWeight}}
+                            <p class="centered_data">
+                                <strong id="axle3_designWeight">{{plateData.axles.axle3.weights.designWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.tyres.tyreSize}}
+                            <p class="centered_data">
+                                <strong id="axle3_tyreSize">{{plateData.axles.axle3.tyres.tyreSize}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="3" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.tyres.plyRating}}
+                            <div class="ply_rating">
+                                <strong id="axle3_plyRating">{{plateData.axles.axle3.tyres.plyRating}}</strong>
+                            </div>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.tyres.fitmentCode}}
+                            <p class="centered_data">
+                                <strong id="axle3_fitmentCode">{{plateData.axles.axle3.tyres.fitmentCode}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="no_border_left_top axle_data">
+                        <p class="axle_number">Axle 4</p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.weights.gbWeight}}
+                            <p class="centered_data">
+                                <strong id="axle4_gbWeight">{{plateData.axles.axle4.weights.gbWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.weights.eecWeight}}
+                            <p class="centered_data">
+                                <strong id="axle4_eecWeight">{{plateData.axles.axle4.weights.eecWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.weights.designWeight}}
+                            <p class="centered_data">
+                                <strong id="axle4_designWeight">{{plateData.axles.axle4.weights.designWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.tyres.tyreSize}}
+                            <p class="centered_data">
+                                <strong id="axle4_tyreSize">{{plateData.axles.axle4.tyres.tyreSize}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="3" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.tyres.plyRating}}
+                            <div class="ply_rating">
+                                <strong id="axle4_plyRating">{{plateData.axles.axle4.tyres.plyRating}}</strong>
+                            </div>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.tyres.fitmentCode}}
+                            <p class="centered_data">
+                                <strong id="axle4_fitmentCode">{{plateData.axles.axle4.tyres.fitmentCode}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_top max_kingpin">
+                        <p class="max_kingpin_title">
+                            <strong>Maximum Kingpin</strong>
+                        </p>
+                        <p class="max_kingpin_title">
+                            <strong>Load</strong>
+                        </p>
+                        <p class="max_kingpin_note">
+                            <span>(Semi-Trailers Only)</span>
+                        </p>
+                    </td>
+                    <td colspan="3" class="no_border_left_top align_top gray_box">
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="max_load">
+                            <strong id="maxLoadOnCoupling">{{plateData.maxLoadOnCoupling}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="6" class="no_border_left_top align_top">
+                        <p class="max_kingpin_title">
+                            *&rsquo;S&rsquo; indicates single wheels
+                        </p>
+                        <p class="max_kingpin_title">
+                            &lsquo;D&rsquo; indicates dual wheels
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="13" class="no_border_top align_top gray_box">
+                        <div class="bottom_gray_div">
                             <div class="inline_elem">
-                                <div class="inline_elem_child test_station">
-                                    <p>Vehicle Testing Station No.</p>
+                                <div class="inline_elem_child empty_div_before_tyre_use">
+                                    {{#if (or (eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
+                                        <p>
+                                            Replacement
+                                        </p>
+                                    {{/if}}
                                 </div>
-                                <div class="inline_elem_child h999">
-                                    <p>H999</p>
+                                <div class="inline_elem_child tyre_use">
+                                    <p>
+                                        Tyre use conditions applicable to vehicle (See note 12)
+                                    </p>
                                 </div>
-                                <div class="inline_elem_child"></div>
-                                <div class="inline_elem_child date_of_issue">
-                                    <p>Date of Issue</p>
-                                </div>
-                                <div class="inline_elem_child issue_date">
-                                    <p id="plateIssueDate">{{formatIsoDate plateData.plateIssueDate}}</p>
-                                </div>
-                            </div>
-                            <div class="inline_elem black_square_container">
-                                <div class="inline_elem_child align_middle black_square_padding">
-                                    <div class="black_square"></div>
-                                </div>
-                                <div class="inline_elem_child signature">
-                                    <p>Signature</p>
-                                </div>
-                                <div class="inline_elem_child signature_container">
-                                    <img class="signature_data" src="{{root}}/assets/images/plate-signature.png"
-                                         alt="signature"
-                                         height="28"/>
+                                <div class="inline_elem_child tyre_use_data">
+                                    <p id="tyreUseCode">
+                                        {{plateData.tyreUseCode}}
+                                    </p>
                                 </div>
                             </div>
-                        </div>
-                        <div class="inline_elem_child bottom_right_container">
-                            <div class="bottom_right_text_container">
-                                <p>
-                                    The plated weights and other plated particulars specified in this plating
-                                    certificate
-                                    are those determined for the vehicle concerned under Sections 49, 57 &amp; 58 of the
-                                    Road
-                                    Traffic Act 1988 and the Regulations made under these Sections
-                                    N.B. All weights in Kilograms &#8211; All Dimensions in Millimetres
+                            <div class="notifiable_alt">
+                                <p>NOTIFIABLE ALTERATIONS (Section 51 (1) (d) of the Road Traffic Act 1988)</p>
+                                <p class="notifiable_alt_following">
+                                    The following alterations in the vehicle or the equipment must
+                                    be notified to the Secretary of State. (See notes 9 to 11)
                                 </p>
+                                <p>(a) &nbsp; An alteration made in the structure or fixed equipment of the vehicle which
+                                    carries the carrying capacity or towing capacity of the vehicle;</p>
+                                <p>(b) &nbsp; An alteration, affecting any part of a braking system or the steering system with
+                                    which the vehicle is equipped or of the means of the operation of that system; of</p>
+                                <p>(c) &nbsp; Any other alteration made in the structure or fixed equipment of the vehicle which
+                                    renders or is likely to render the vehicle unsafe to travel on roads at any weight equal to
+                                    any weight shown in column (2) of the plating certificate.</p>
+                            </div>
+                            <div class="inline_elem bottom_details">
+                                <div class="inline_elem_child bottom_left_details">
+                                    <div class="inline_elem">
+                                        <div class="inline_elem_child test_station">
+                                            <p>Vehicle Testing Station No.</p>
+                                        </div>
+                                        <div class="inline_elem_child h999">
+                                            <p>H999</p>
+                                        </div>
+                                        <div class="inline_elem_child"></div>
+                                        <div class="inline_elem_child date_of_issue">
+                                            <p>Date of Issue</p>
+                                        </div>
+                                        <div class="inline_elem_child issue_date">
+                                            <p id="plateIssueDate">{{formatIsoDate plateData.plateIssueDate}}</p>
+                                        </div>
+                                    </div>
+                                    <div class="inline_elem black_square_container">
+                                        <div class="inline_elem_child align_middle black_square_padding">
+                                            <div class="black_square"></div>
+                                        </div>
+                                        <div class="inline_elem_child signature">
+                                            <p>Signature</p>
+                                        </div>
+                                        <div class="inline_elem_child signature_container">
+                                            <img class="signature_data" src="{{root}}/assets/images/plate-signature.png"
+                                                 alt="signature"
+                                                 height="28"/>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="inline_elem_child bottom_right_container">
+                                    <div class="bottom_right_text_container">
+                                        <p>
+                                            The plated weights and other plated particulars specified in this plating
+                                            certificate
+                                            are those determined for the vehicle concerned under Sections 49, 57 &amp; 58 of the
+                                            Road
+                                            Traffic Act 1988 and the Regulations made under these Sections
+                                            N.B. All weights in Kilograms &#8211; All Dimensions in Millimetres
+                                        </p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </div>
-            </td>
-        </tr>
-        </tbody>
-        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
         </td>
         <td class='gap'>
         </td>
         <td class='table-half'>
-        <table class="vtg6">
+            <table class="vtg6">
                 <tbody>
                 <tr>
                     <td colspan="4" rowspan="2" class="logo">
@@ -1273,6 +1273,58 @@
 
 <table>
     <td class='table-half'>
+        <div class="vtg6_secondPage">
+            <p class="vtg6_display">
+                DISPLAY OF MINISTRY PLATE
+            </p>
+            <ol>
+                <li>
+                    <p class="vtg6_securely_affixed">
+                        This plate must be securely affixed:-
+                    </p>
+                    <ol class="securely_affixed_options">
+                        <li>
+                            In the cab of the vehicle; or
+                        </li>
+                        <li>
+                            elsewhere on the vehicle if it is constructed without a cab (e.g. a trailer) in a conspicuous
+                            and readily accessible position and must be legible at all times (Regulation 70 of the Road
+                            Vehicle Construction and Use Regulations 1986).
+                        </li>
+                    </ol>
+                </li>
+            </ol>
+            <p class="vtg6_loss">
+                LOSS
+            </p>
+            <ol start="2">
+                <li>
+                    If this plate is lost or defaced, an application for a replacement may be made to:
+                </li>
+            </ol>
+            <div class="vtg6_dvsa">
+                <p>
+                    Driver and Vehicle Standards Agency (DVSA)
+                </p>
+                <p>
+                    Replacements Section
+                </p>
+                <p>
+                    Ellipse
+                </p>
+                <p>
+                    Padley Road
+                </p>
+                <p>
+                    Swansea, SA1 8AN
+                </p>
+                <p>
+                    A fee will be charged.
+                </p>
+            </div>
+        </div>
+    </td>
+    <td class='table-half'>
         <div class="secondPage">
             <p class="notes_title">NOTES</p>
             <p><strong>PLATED WEIGHTS</strong></p>
@@ -1390,58 +1442,6 @@
                 </li>
                 <li style="list-style-type: none;">(Rev April 2014)</li>
             </ol>
-        </div>
-    </td>
-    <td class='table-half'>
-        <div class="vtg6_secondPage">
-            <p class="vtg6_display">
-                DISPLAY OF MINISTRY PLATE
-            </p>
-            <ol>
-                <li>
-                    <p class="vtg6_securely_affixed">
-                        This plate must be securely affixed:-
-                    </p>
-                    <ol class="securely_affixed_options">
-                        <li>
-                            In the cab of the vehicle; or
-                        </li>
-                        <li>
-                            elsewhere on the vehicle if it is constructed without a cab (e.g. a trailer) in a conspicuous
-                            and readily accessible position and must be legible at all times (Regulation 70 of the Road
-                            Vehicle Construction and Use Regulations 1986).
-                        </li>
-                    </ol>
-                </li>
-            </ol>
-            <p class="vtg6_loss">
-                LOSS
-            </p>
-            <ol start="2">
-                <li>
-                    If this plate is lost or defaced, an application for a replacement may be made to:
-                </li>
-            </ol>
-            <div class="vtg6_dvsa">
-                <p>
-                    Driver and Vehicle Standards Agency (DVSA)
-                </p>
-                <p>
-                    Replacements Section
-                </p>
-                <p>
-                    Ellipse
-                </p>
-                <p>
-                    Padley Road
-                </p>
-                <p>
-                    Swansea, SA1 8AN
-                </p>
-                <p>
-                    A fee will be charged.
-                </p>
-            </div>
         </div>
     </td>
 </table>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
@@ -72,7 +72,7 @@
                 </tr>
                 <tr>
                     <td colspan="13" class="no_border_top align_top">
-                        <p class="tyre_approval">Tyre Approval No. &nbsp; <strong
+                        <p class="tyre_approval">Type Approval No. &nbsp; <strong
                                 id="approvalTypeNumber">{{plateData.approvalTypeNumber}}</strong></p>
                     </td>
                 </tr>
@@ -759,7 +759,7 @@
                 </tr>
                 <tr>
                     <td colspan="13" class="no_border_top align_top">
-                        <p class="tyre_approval">Tyre Approval No. &nbsp; <strong
+                        <p class="tyre_approval">Type Approval No. &nbsp; <strong
                                 id="approvalTypeNumber">{{plateData.approvalTypeNumber}}</strong></p>
                     </td>
                 </tr>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
@@ -1315,7 +1315,11 @@
                 <li>If the last letter in the function box is &lsquo;R&rsquo; road friendly suspension is fitted</li>
                 <li>All weight shown are subject to the fitting of correct tyres</li>
                 <li>The weight applies to combined transport operations.</li>
-                <li style="list-style-type: none;">(6-8 deleted)</li>
+                <li>This dimension only applies to drawn vehicles of trailers and semi-trailers</li>
+                <li>This dimension only applies to trailer and semi-trailers</li>
+                <li>Where there is no weight shown in the EEC maximum permitted weights column this is because there is no
+                    EEC standard relating to that weight.
+                </li>
             </ol>
             <p><strong>NOTIFIABLE ALTERATIONS </strong></p>
             <ol start="9">

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
@@ -1238,10 +1238,31 @@
                             <li>
                                 The weight applies to combined transport operations
                             </li>
+                            <li>
+                                This dimension only applies to drawn vehicles of
+                                trailers and semi - trailers
+                            </li>
                         </ol>
                     </td>
-                    <td colspan="5" class="no_border_top align_top notes_cont gray_box">
-
+                    <td colspan="5" class="no_border_top align_top notes_cont">
+                        <p class="notes_cont_title">
+                            <strong>NOTES (Cont’d)</strong>
+                        </p>
+                        <ol start="7">
+                            <li>
+                                This dimension only applies to trailer and semi-
+                                trailers
+                            </li>
+                            <li>
+                                Where there is no weight shown in the EEC maximum
+                                permitted weights column this is because there is no EEC
+                                standard relating to that weight.
+                            </li>
+                        </ol>
+                        <p class="notes_nb">
+                            N.B All weights in Kilograms – all dimensions in
+                            Millimetres
+                        </p>
                     </td>
                 </tr>
                 </tbody>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
@@ -12,666 +12,699 @@
 
 <body>
 <div class="separatePage">
-<table>
-<td class='table-half'>
-    <table class="vtg7">
-        <tbody>
-        <tr>
-            <td colspan="4" rowspan="2" class="logo">
-                <img src="{{root}}/assets/images/dvsa-crest-1.1.png" alt="DVSA" width="110"/>
-            </td>
-            <td colspan="4" rowspan="2" class="plating_certificate">
-                <p class="department_for_transport">
-                    <strong>Department For Transport</strong></p>
-                <p class="road_traffic">
-                    ROAD TRAFFIC ACT 1988 SECTIONS 41, 49, 57 &amp; 58 EXAMINATION OF GOODS VEHICLE
-                </p>
-                <p class="proof_of_compliance">
-                    This is issued as proof of compliance with the weights and dimensions directive 85/3/EEC
-                </p>
-                <div class="inline_elem">
-                    <div class="inline_elem_child">
-                        <p class="plating_cert">
-                            Plating Certificate
+    <table>
+        <td class='table-half'>
+            <table class="vtg7">
+                <tbody>
+                <tr>
+                    <td colspan="4" rowspan="2" class="logo">
+                        <img src="{{root}}/assets/images/dvsa-crest-1.1.png" alt="DVSA" width="110"/>
+                    </td>
+                    <td colspan="4" rowspan="2" class="plating_certificate">
+                        <p class="department_for_transport">
+                            <strong>Department For Transport</strong></p>
+                        <p class="road_traffic">
+                            ROAD TRAFFIC ACT 1988 SECTIONS 41, 49, 57 &amp; 58 EXAMINATION OF GOODS VEHICLE
                         </p>
-                    </div>
-                    <div class="inline_elem_child vtg7a">
-                        <p>
-                            VTG7A
+                        <p class="proof_of_compliance">
+                            This is issued as proof of compliance with the weights and dimensions directive 85/3/EEC
                         </p>
-                        <p>
-                            Rev 2010
-                        </p>
-                    </div>
-                </div>
-            </td>
-            <td colspan="5" class="plating_certificate">
-                <p class="serial_dtp"> Serial No.&nbsp;</p>
-                <p class="serial_value" id="plateSerialNumber">{{plateData.plateSerialNumber}}</p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="6" class="dtp_data">
-                <p class="serial_dtp"> DTp Ref. No.&nbsp;</p>
-                <p class="dtp_value" id="dtpNumber">{{plateData.dtpNumber}}</p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="3" class="no_border_top align_top">
-                <p class="vehicle_identifier">Reg./ Ident Mark</p>
-                <p class="vehicle_identifier_data" id="primaryVrm">{{plateData.primaryVrm}}</p>
-            </td>
-            <td colspan="5" class="no_border_left_top align_top">
-                <p class="vehicle_identifier">Vehicle Identification No.</p>
-                <p class="vehicle_identifier_data" id="vin">{{plateData.vin}}</p>
-            </td>
-            <td colspan="5" class="no_border_left_top align_top">
-                <p class="vehicle_identifier">Variant</p>
-                <p class="vehicle_identifier_data" id="variantNumber">{{plateData.variantNumber}}</p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="13" class="no_border_top align_top">
-                <p class="tyre_approval">Tyre Approval No. &nbsp; <strong
-                        id="approvalTypeNumber">{{plateData.approvalTypeNumber}}</strong></p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="8" class="no_border_top align_top manufacturer">
-                <div class="inline_elem">
-                    <div class="inline_elem_child manufacturer_model_container">
-                        <p>
-                            <span>Manufacturer/</span>
-                        </p>
-                        <p>
-                            <span>Model</span>
-                        </p>
-                    </div>
-                    <div class="inline_elem_child">
-                        <p class="make_model_container">
-                            <span class="manufacturer_data" id="make-model">{{plateData.make}}/{{plateData.model}}</span>
-                        </p>
-                    </div>
-                </div>
-            </td>
-            <td colspan="5" class="no_border_left_top align_top speed_limiter">
-                <p>
-                    <span>Speed</span>
-                </p>
-                <p>
-                    <span>Limiter</span>
-                    <span class="speed_limiter_data" id="speedLimiterMrk">{{plateData.speedLimiterMrk}}</span>
-                </p>
-                <p>
-                    <span>Exempt</span>
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="4" class="no_border_top function_code">
-                <div class="inline_elem_child">
-                    <p>
-                        <span>Function</span>
-                    </p>
-                    <p>
-                        <span>(See note 3)</span>
-                    </p>
-                </div>
-                <div class="inline_elem_child align_middle">
-                    <span class="function_code_data" id="functionCode">{{plateData.functionCode}}</span>
-                </div>
-            </td>
-            <td colspan="4" class="no_border_left_top regn_date">
-                <div class="inline_elem_child">
-                    <p>
-                        <span>Year of Original</span>
-                    </p>
-                    <p> Registration </p>
-                </div>
-                <div class="inline_elem_child align_middle">
-                    <span class="regn_date_data" id="regnDate">{{plateData.regnDate}}</span>
-                </div>
-            </td>
-            <td colspan="5" class="no_border_left_top manufacture_year">
-                <div class="inline_elem_child">
-                    <p>
-                        <span>Year of</span>
-                    </p>
-                    <p>
-                        <span>Manufacture</span>
-                    </p>
-                </div>
-                <div class="inline_elem_child align_middle">
-                    <span class="manufacture_year_data" id="manufactureYear">{{plateData.manufactureYear}}</span>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" rowspan="2" class="weights_description width_25">
-                <div class="inline_elem description_of_weights">
-                    <span class="inline_elem_child weight_numbering"> (1) </span>
-                    <span class="inline_elem_child weight_title">Description of Weights Applicable to vehicle</span>
-                </div>
-            </td>
-            <td colspan="2" rowspan="2" class="no_border_left_top align_top width_25">
-                <div class="inline_elem">
-                    <span class="inline_elem_child weight_numbering"> (2) </span>
-                    <span class="inline_elem_child weight_title">Weights not to be exceeded in Gt. Britain</span>
-                </div>
-            </td>
-            <td rowspan="2" class="no_border_left_top align_top width_25">
-                <div class="inline_elem">
-                    <span class="inline_elem_child weight_numbering"> (3) </span>
-                    <span class="inline_elem_child weight_title">EEC Maximum permitted weights</span>
-                </div>
-                <p class="weight_notes">(See note 8)</p>
-            </td>
-            <td colspan="2" rowspan="2" class="no_border_left_top align_top width_25">
-                <div class="inline_elem">
-                    <span class="inline_elem_child weight_numbering"> (4) </span>
-                    <span class="inline_elem_child weight_title">Design Weights</span>
-                </div>
-                <p class="weight_notes">(if higher than shown in column 2)</p>
-            </td>
-            <td colspan="2" class="border_left length_width gray_box">
-            </td>
-            <td colspan="4" class="border_right length_width gray_box">
-
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="border_left align_middle gray_box">
-            </td>
-            <td colspan="4" class="border_right align_middle gray_box">
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_top align_middle">
-                <p class="centered_title">
-                    <strong class="weight_titles">Gross Weight</strong>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weight_notes">(See notes 1 &amp; 4)</span>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="grossGbWeight">{{plateData.grossGbWeight}}</strong>
-                </p>
-            </td>
-            <td class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="grossEecWeight">{{plateData.grossEecWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="grossDesignWeight">{{plateData.grossDesignWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="border_left align_middle gray_box">
-            </td>
-            <td colspan="2" class="no_border gray_box align_top">
-                <div class="centered_title coupling_max_min">
-                </div>
-            </td>
-            <td colspan="2" class="border_right gray_box align_top">
-                <div class="centered_title coupling_max_min">
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_top align_middle">
-                <p class="centered_title">
-                    <strong class="weight_titles">Train Weight</strong>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weight_notes">(See note 2)</span>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="trainGbWeight">{{plateData.trainGbWeight}}</strong>
-                </p>
-            </td>
-            <td class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="trainEecWeight">{{plateData.trainEecWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="trainDesignWeight">{{plateData.trainDesignWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="border_left border_bottom align_middle gray_box">
-            </td>
-            <td colspan="2" class="border_bottom align_top gray_box">
-            </td>
-            <td colspan="2" class="border_bottom border_right align_top gray_box">
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_top align_middle">
-                <p class="centered_title">
-                    <strong class="weight_titles">Max. Train Weight</strong>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weight_notes">(See note 5)</span>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="maxTrainGbWeight">{{plateData.maxTrainGbWeight}}</strong>
-                </p>
-            </td>
-            <td class="no_border_left_top align_middle">
-                <p class="centered_data">
-                    <strong id="maxTrainEecWeight">{{plateData.maxTrainEecWeight}}</strong>
-                </p>
-            </td>
-            <td colspan="2" class="no_border_left_top gray_box">
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <div>
-                    <p class="centered_title tyres">
-                        <strong class="axle_weight_notes">Tyre size</strong>
-                    </p>
-                    <p class="centered_title tyres">
-                        <span class="axle_weight_notes">(Fitted at time of issue of certificate)</span>
-                    </p>
-                </div>
-            </td>
-            <td colspan="3" class="no_border_left_top align_top">
-                <div>
-                    <p class="ply_load_index"> Ply rating or load index</p>
-                </div>
-            </td>
-            <td class="no_border_left_top align_top">
-                <div class="centered_title">
-                    <p class="fitment_code">*S</p>
-                    <p class="fitment_code">or</p>
-                    <p class="fitment_code">D</p>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td rowspan="4" class="no_border_top align_top">
-                <p class="centered_title">
-                    <strong class="axle_weights">Axle</strong>
-                </p>
-                <p class="centered_title">
-                    <strong class="axle_weights">Weights</strong>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">(Axle</span>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">numbered</span>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">from front</span>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">to rear)</span>
-                </p>
-                <p class="centered_title">
-                    <span class="axle_weights_notes">(See note 1)</span>
-                </p>
-            </td>
-            <td class="no_border_left_top">
-                <p class="axle_number"> Axle 1 </p>
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.weights.gbWeight}}
-                    <p class="centered_data">
-                        <strong id="axle1_gbWeight">{{plateData.axles.axle1.weights.gbWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.weights.eecWeight}}
-                    <p class="centered_data">
-                        <strong id="axle1_eecWeight">{{plateData.axles.axle1.weights.eecWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.weights.designWeight}}
-                    <p class="centered_data">
-                        <strong id="axle1_designWeight">{{plateData.axles.axle1.weights.designWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.tyres.tyreSize}}
-                    <p class="centered_data">
-                        <strong id="axle1_tyreSize">{{plateData.axles.axle1.tyres.tyreSize}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="3" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.tyres.plyRating}}
-                    <div class="ply_rating">
-                        <strong id="axle1_plyRating">{{plateData.axles.axle1.tyres.plyRating}}</strong>
-                    </div>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle1.tyres.fitmentCode}}
-                    <p class="centered_data">
-                        <strong id="axle1_fitmentCode">{{plateData.axles.axle1.tyres.fitmentCode}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-        </tr>
-        <tr>
-            <td class="no_border_left_top axle_data">
-                <p class="axle_number"> Axle 2 </p>
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.weights.gbWeight}}
-                    <p class="centered_data">
-                        <strong id="axle2_gbWeight">{{plateData.axles.axle2.weights.gbWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.weights.eecWeight}}
-                    <p class="centered_data">
-                        <strong id="axle2_eecWeight">{{plateData.axles.axle2.weights.eecWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.weights.designWeight}}
-                    <p class="centered_data">
-                        <strong id="axle2_designWeight">{{plateData.axles.axle2.weights.designWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.tyres.tyreSize}}
-                    <p class="centered_data">
-                        <strong id="axle2_tyreSize">{{plateData.axles.axle2.tyres.tyreSize}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="3" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.tyres.plyRating}}
-                    <div class="ply_rating">
-                        <strong id="axle2_plyRating">{{plateData.axles.axle2.tyres.plyRating}}</strong>
-                    </div>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle2.tyres.fitmentCode}}
-                    <p class="centered_data">
-                        <strong id="axle2_fitmentCode">{{plateData.axles.axle2.tyres.fitmentCode}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-        </tr>
-        <tr>
-            <td class="no_border_left_top align_middle">
-                <p class="axle_number"> Axle 3 </p>
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.weights.gbWeight}}
-                    <p class="centered_data">
-                        <strong id="axle3_gbWeight">{{plateData.axles.axle3.weights.gbWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.weights.eecWeight}}
-                    <p class="centered_data">
-                        <strong id="axle3_eecWeight">{{plateData.axles.axle3.weights.eecWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.weights.designWeight}}
-                    <p class="centered_data">
-                        <strong id="axle3_designWeight">{{plateData.axles.axle3.weights.designWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.tyres.tyreSize}}
-                    <p class="centered_data">
-                        <strong id="axle3_tyreSize">{{plateData.axles.axle3.tyres.tyreSize}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="3" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.tyres.plyRating}}
-                    <div class="ply_rating">
-                        <strong id="axle3_plyRating">{{plateData.axles.axle3.tyres.plyRating}}</strong>
-                    </div>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle3.tyres.fitmentCode}}
-                    <p class="centered_data">
-                        <strong id="axle3_fitmentCode">{{plateData.axles.axle3.tyres.fitmentCode}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-        </tr>
-        <tr>
-            <td class="no_border_left_top axle_data">
-                <p class="axle_number">Axle 4</p>
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.weights.gbWeight}}
-                    <p class="centered_data">
-                        <strong id="axle4_gbWeight">{{plateData.axles.axle4.weights.gbWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.weights.eecWeight}}
-                    <p class="centered_data">
-                        <strong id="axle4_eecWeight">{{plateData.axles.axle4.weights.eecWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.weights.designWeight}}
-                    <p class="centered_data">
-                        <strong id="axle4_designWeight">{{plateData.axles.axle4.weights.designWeight}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="2" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.tyres.tyreSize}}
-                    <p class="centered_data">
-                        <strong id="axle4_tyreSize">{{plateData.axles.axle4.tyres.tyreSize}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td colspan="3" class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.tyres.plyRating}}
-                    <div class="ply_rating">
-                        <strong id="axle4_plyRating">{{plateData.axles.axle4.tyres.plyRating}}</strong>
-                    </div>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-            <td class="no_border_left_top axle_data">
-                {{#if plateData.axles.axle4.tyres.fitmentCode}}
-                    <p class="centered_data">
-                        <strong id="axle4_fitmentCode">{{plateData.axles.axle4.tyres.fitmentCode}}</strong>
-                    </p>
-                {{else}}
-                    <br/>
-                {{/if}}
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" class="no_border_top max_kingpin">
-                <p class="max_kingpin_title">
-                    <strong>Maximum Kingpin</strong>
-                </p>
-                <p class="max_kingpin_title">
-                    <strong>Load</strong>
-                </p>
-                <p class="max_kingpin_note">
-                    <span>(Semi-Trailers Only)</span>
-                </p>
-            </td>
-            <td colspan="3" class="no_border_left_top align_top gray_box">
-            </td>
-            <td colspan="2" class="no_border_left_top align_middle">
-                <p class="max_load">
-                    <strong id="maxLoadOnCoupling">{{plateData.maxLoadOnCoupling}}</strong>
-                </p>
-            </td>
-            <td colspan="6" class="no_border_left_top align_top">
-                <p class="max_kingpin_title">
-                    *&rsquo;S&rsquo; indicates single wheels
-                </p>
-                <p class="max_kingpin_title">
-                    &lsquo;D&rsquo; indicates dual wheels
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="13" class="no_border_top align_top gray_box">
-                <div class="bottom_gray_div">
-                    <div class="inline_elem">
-                        <div class="inline_elem_child empty_div_before_tyre_use">
-                        {{#if (or (eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
-                            <p>
-                                Replacement
-                            </p>
-                         {{/if}}
-                        </div>
-                        <div class="inline_elem_child tyre_use">
-                            <p>
-                                Tyre use conditions applicable to vehicle (See note 12)
-                            </p>
-                        </div>
-                        <div class="inline_elem_child tyre_use_data">
-                            <p id="tyreUseCode">
-                                {{plateData.tyreUseCode}}
-                            </p>
-                        </div>
-                    </div>
-                    <div class="notifiable_alt">
-                        <p>NOTIFIABLE ALTERATIONS (Section 51 (1) (d) of the Road Traffic Act 1988)</p>
-                        <p class="notifiable_alt_following">
-                            The following alterations in the vehicle or the equipment must
-                            be notified to the Secretary of State. (See notes 9 to 11)
-                        </p>
-                        <p>(a) &nbsp; An alteration made in the structure or fixed equipment of the vehicle which
-                            carries the carrying capacity or towing capacity of the vehicle;</p>
-                        <p>(b) &nbsp; An alteration, affecting any part of a braking system or the steering system with
-                            which the vehicle is equipped or of the means of the operation of that system; of</p>
-                        <p>(c) &nbsp; Any other alteration made in the structure or fixed equipment of the vehicle which
-                            renders or is likely to render the vehicle unsafe to travel on roads at any weight equal to
-                            any weight shown in column (2) of the plating certificate.</p>
-                    </div>
-                    <div class="inline_elem bottom_details">
-                        <div class="inline_elem_child bottom_left_details">
-                            <div class="inline_elem">
-                                <div class="inline_elem_child test_station">
-                                    <p>Vehicle Testing Station No.</p>
-                                </div>
-                                <div class="inline_elem_child h999">
-                                    <p>H999</p>
-                                </div>
-                                <div class="inline_elem_child"></div>
-                                <div class="inline_elem_child date_of_issue">
-                                    <p>Date of Issue</p>
-                                </div>
-                                <div class="inline_elem_child issue_date">
-                                    <p id="plateIssueDate">{{formatIsoDate plateData.plateIssueDate}}</p>
-                                </div>
+                        <div class="inline_elem">
+                            <div class="inline_elem_child">
+                                <p class="plating_cert">
+                                    Plating Certificate
+                                </p>
                             </div>
-                            <div class="inline_elem black_square_container">
-                                <div class="inline_elem_child align_middle black_square_padding">
-                                    <div class="black_square"></div>
-                                </div>
-                                <div class="inline_elem_child signature">
-                                    <p>Signature</p>
-                                </div>
-                                <div class="inline_elem_child signature_container">
-                                    <img class="signature_data" src="{{root}}/assets/images/plate-signature.png"
-                                         alt="signature"
-                                         height="28"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="inline_elem_child bottom_right_container">
-                            <div class="bottom_right_text_container">
+                            <div class="inline_elem_child vtg7a">
                                 <p>
-                                    The plated weights and other plated particulars specified in this plating
-                                    certificate
-                                    are those determined for the vehicle concerned under Sections 49, 57 &amp; 58 of the
-                                    Road
-                                    Traffic Act 1988 and the Regulations made under these Sections
-                                    N.B. All weights in Kilograms &#8211; All Dimensions in Millimetres
+                                    VTG7A
+                                </p>
+                                <p>
+                                    Rev 2010
                                 </p>
                             </div>
                         </div>
-                    </div>
-                </div>
-            </td>
-        </tr>
-        </tbody>
-        </table>
+                    </td>
+                    <td colspan="5" class="plating_certificate">
+                        <p class="serial_dtp"> Serial No.&nbsp;</p>
+                        <p class="serial_value" id="plateSerialNumber">{{plateData.plateSerialNumber}}</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="6" class="dtp_data">
+                        <p class="serial_dtp"> DTp Ref. No.&nbsp;</p>
+                        <p class="dtp_value" id="dtpNumber">{{plateData.dtpNumber}}</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="3" class="no_border_top align_top">
+                        <p class="vehicle_identifier">Reg./ Ident Mark</p>
+                        <p class="vehicle_identifier_data" id="primaryVrm">{{plateData.primaryVrm}}</p>
+                    </td>
+                    <td colspan="5" class="no_border_left_top align_top">
+                        <p class="vehicle_identifier">Vehicle Identification No.</p>
+                        <p class="vehicle_identifier_data" id="vin">{{plateData.vin}}</p>
+                    </td>
+                    <td colspan="5" class="no_border_left_top align_top">
+                        <p class="vehicle_identifier">Variant</p>
+                        <p class="vehicle_identifier_data" id="variantNumber">{{plateData.variantNumber}}</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="13" class="no_border_top align_top">
+                        <p class="tyre_approval">Tyre Approval No. &nbsp; <strong
+                                id="approvalTypeNumber">{{plateData.approvalTypeNumber}}</strong></p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="8" class="no_border_top align_top manufacturer">
+                        <div class="inline_elem">
+                            <div class="inline_elem_child manufacturer_model_container">
+                                <p>
+                                    <span>Manufacturer/</span>
+                                </p>
+                                <p>
+                                    <span>Model</span>
+                                </p>
+                            </div>
+                            <div class="inline_elem_child">
+                                <p class="make_model_container">
+                                    <span class="manufacturer_data" id="make-model">{{plateData.make}}/{{plateData.model}}</span>
+                                </p>
+                            </div>
+                        </div>
+                    </td>
+                    <td colspan="5" class="no_border_left_top align_top speed_limiter">
+                        <p>
+                            <span>Speed</span>
+                        </p>
+                        <p>
+                            <span>Limiter</span>
+                            <span class="speed_limiter_data" id="speedLimiterMrk">{{plateData.speedLimiterMrk}}</span>
+                        </p>
+                        <p>
+                            <span>Exempt</span>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="4" class="no_border_top function_code">
+                        <div class="inline_elem_child">
+                            <p>
+                                <span>Function</span>
+                            </p>
+                            <p>
+                                <span>(See note 3)</span>
+                            </p>
+                        </div>
+                        <div class="inline_elem_child align_middle">
+                            <span class="function_code_data" id="functionCode">{{plateData.functionCode}}</span>
+                        </div>
+                    </td>
+                    <td colspan="4" class="no_border_left_top regn_date">
+                        <div class="inline_elem_child">
+                            <p>
+                                <span>Year of Original</span>
+                            </p>
+                            <p> Registration </p>
+                        </div>
+                        <div class="inline_elem_child align_middle">
+                            <span class="regn_date_data" id="regnDate">{{formatIsoDate plateData.regnDate}}</span>
+                        </div>
+                    </td>
+                    <td colspan="5" class="no_border_left_top manufacture_year">
+                        <div class="inline_elem_child">
+                            <p>
+                                <span>Year of</span>
+                            </p>
+                            <p>
+                                <span>Manufacture</span>
+                            </p>
+                        </div>
+                        <div class="inline_elem_child align_middle">
+                            <span class="manufacture_year_data" id="manufactureYear">{{plateData.manufactureYear}}</span>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" rowspan="2" class="weights_description width_25">
+                        <div class="inline_elem description_of_weights">
+                            <span class="inline_elem_child weight_numbering"> (1) </span>
+                            <span class="inline_elem_child weight_title">Description of Weights Applicable to vehicle</span>
+                        </div>
+                    </td>
+                    <td colspan="2" rowspan="2" class="no_border_left_top align_top width_25">
+                        <div class="inline_elem">
+                            <span class="inline_elem_child weight_numbering"> (2) </span>
+                            <span class="inline_elem_child weight_title">Weights not to be exceeded in Gt. Britain</span>
+                        </div>
+                    </td>
+                    <td rowspan="2" class="no_border_left_top align_top width_25">
+                        <div class="inline_elem">
+                            <span class="inline_elem_child weight_numbering"> (3) </span>
+                            <span class="inline_elem_child weight_title">EEC Maximum permitted weights</span>
+                        </div>
+                        <p class="weight_notes">(See note 8)</p>
+                    </td>
+                    <td colspan="2" rowspan="2" class="no_border_left_top align_top width_25">
+                        <div class="inline_elem">
+                            <span class="inline_elem_child weight_numbering"> (4) </span>
+                            <span class="inline_elem_child weight_title">Design Weights</span>
+                        </div>
+                        <p class="weight_notes">(if higher than shown in column 2)</p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top length_width">
+                        <p class="centered_data"><strong>Length</strong></p>
+                    </td>
+                    <td colspan="4" class="no_border_left_top length_width">
+                        <p class="centered_data"><strong>Width</strong></p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="dimensionLength">{{plateData.dimensionLength}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="4" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="dimensionWidth">{{plateData.dimensionWidth}}</strong>
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_top align_middle">
+                        <p class="centered_title">
+                            <strong class="weight_titles">Gross Weight</strong>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weight_notes">(See notes 1 &amp; 4)</span>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="grossGbWeight">{{plateData.grossGbWeight}}</strong>
+                        </p>
+                    </td>
+                    <td class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="grossEecWeight">{{plateData.grossEecWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="grossDesignWeight">{{plateData.grossDesignWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <div class="coupling_foremost">
+                            <span>a. Coupling centre to vehicle foremost part (See note 6)</span>
+                        </div>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Max</strong>
+                            <p class="centered_data">
+                                <strong id="frontVehicleTo5thWheelCouplingMax">{{plateData.frontVehicleTo5thWheelCouplingMax}}</strong>
+                            </p>
+                        </div>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Min</strong>
+                            <p class="centered_data">
+                                <strong id="frontVehicleTo5thWheelCouplingMin">{{plateData.frontVehicleTo5thWheelCouplingMin}}</strong>
+                            </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_top align_middle">
+                        <p class="centered_title">
+                            <strong class="weight_titles">Train Weight</strong>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weight_notes">(See note 2)</span>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="trainGbWeight">{{plateData.trainGbWeight}}</strong>
+                        </p>
+                    </td>
+                    <td class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="trainEecWeight">{{plateData.trainEecWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="trainDesignWeight">{{plateData.trainDesignWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <div class="coupling_rearmost">
+                            <span>b. Coupling centre to vehicle rearmost part (See note 7)</span>
+                        </div>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Max</strong>
+                            <p class="centered_data">
+                                <strong id="couplingCenterToRearTrlMax">{{plateData.couplingCenterToRearTrlMax}}</strong>
+                            </p>
+                        </div>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Min</strong>
+                            <p class="centered_data">
+                                <strong id="couplingCenterToRearTrlMin">{{plateData.couplingCenterToRearTrlMin}}</strong>
+                            </p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_top align_middle">
+                        <p class="centered_title">
+                            <strong class="weight_titles">Max. Train Weight</strong>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weight_notes">(See note 5)</span>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="maxTrainGbWeight">{{plateData.maxTrainGbWeight}}</strong>
+                        </p>
+                    </td>
+                    <td class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="maxTrainEecWeight">{{plateData.maxTrainEecWeight}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top gray_box">
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <div>
+                            <p class="centered_title tyres">
+                                <strong class="axle_weight_notes">Tyre size</strong>
+                            </p>
+                            <p class="centered_title tyres">
+                                <span class="axle_weight_notes">(Fitted at time of issue of certificate)</span>
+                            </p>
+                        </div>
+                    </td>
+                    <td colspan="3" class="no_border_left_top align_top">
+                        <div>
+                            <p class="ply_load_index"> Ply rating or load index</p>
+                        </div>
+                    </td>
+                    <td class="no_border_left_top align_top">
+                        <div class="centered_title">
+                            <p class="fitment_code">*S</p>
+                            <p class="fitment_code">or</p>
+                            <p class="fitment_code">D</p>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td rowspan="4" class="no_border_top align_top">
+                        <p class="centered_title">
+                            <strong class="axle_weights">Axle</strong>
+                        </p>
+                        <p class="centered_title">
+                            <strong class="axle_weights">Weights</strong>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">(Axle</span>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">numbered</span>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">from front</span>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">to rear)</span>
+                        </p>
+                        <p class="centered_title">
+                            <span class="axle_weights_notes">(See note 1)</span>
+                        </p>
+                    </td>
+                    <td class="no_border_left_top">
+                        <p class="axle_number"> Axle 1 </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.weights.gbWeight}}
+                            <p class="centered_data">
+                                <strong id="axle1_gbWeight">{{plateData.axles.axle1.weights.gbWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.weights.eecWeight}}
+                            <p class="centered_data">
+                                <strong id="axle1_eecWeight">{{plateData.axles.axle1.weights.eecWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.weights.designWeight}}
+                            <p class="centered_data">
+                                <strong id="axle1_designWeight">{{plateData.axles.axle1.weights.designWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.tyres.tyreSize}}
+                            <p class="centered_data">
+                                <strong id="axle1_tyreSize">{{plateData.axles.axle1.tyres.tyreSize}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="3" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.tyres.plyRating}}
+                            <div class="ply_rating">
+                                <strong id="axle1_plyRating">{{plateData.axles.axle1.tyres.plyRating}}</strong>
+                            </div>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle1.tyres.fitmentCode}}
+                            <p class="centered_data">
+                                <strong id="axle1_fitmentCode">{{plateData.axles.axle1.tyres.fitmentCode}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="no_border_left_top axle_data">
+                        <p class="axle_number"> Axle 2 </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.weights.gbWeight}}
+                            <p class="centered_data">
+                                <strong id="axle2_gbWeight">{{plateData.axles.axle2.weights.gbWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.weights.eecWeight}}
+                            <p class="centered_data">
+                                <strong id="axle2_eecWeight">{{plateData.axles.axle2.weights.eecWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.weights.designWeight}}
+                            <p class="centered_data">
+                                <strong id="axle2_designWeight">{{plateData.axles.axle2.weights.designWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.tyres.tyreSize}}
+                            <p class="centered_data">
+                                <strong id="axle2_tyreSize">{{plateData.axles.axle2.tyres.tyreSize}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="3" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.tyres.plyRating}}
+                            <div class="ply_rating">
+                                <strong id="axle2_plyRating">{{plateData.axles.axle2.tyres.plyRating}}</strong>
+                            </div>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle2.tyres.fitmentCode}}
+                            <p class="centered_data">
+                                <strong id="axle2_fitmentCode">{{plateData.axles.axle2.tyres.fitmentCode}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="no_border_left_top align_middle">
+                        <p class="axle_number"> Axle 3 </p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.weights.gbWeight}}
+                            <p class="centered_data">
+                                <strong id="axle3_gbWeight">{{plateData.axles.axle3.weights.gbWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.weights.eecWeight}}
+                            <p class="centered_data">
+                                <strong id="axle3_eecWeight">{{plateData.axles.axle3.weights.eecWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.weights.designWeight}}
+                            <p class="centered_data">
+                                <strong id="axle3_designWeight">{{plateData.axles.axle3.weights.designWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.tyres.tyreSize}}
+                            <p class="centered_data">
+                                <strong id="axle3_tyreSize">{{plateData.axles.axle3.tyres.tyreSize}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="3" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.tyres.plyRating}}
+                            <div class="ply_rating">
+                                <strong id="axle3_plyRating">{{plateData.axles.axle3.tyres.plyRating}}</strong>
+                            </div>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle3.tyres.fitmentCode}}
+                            <p class="centered_data">
+                                <strong id="axle3_fitmentCode">{{plateData.axles.axle3.tyres.fitmentCode}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="no_border_left_top axle_data">
+                        <p class="axle_number">Axle 4</p>
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.weights.gbWeight}}
+                            <p class="centered_data">
+                                <strong id="axle4_gbWeight">{{plateData.axles.axle4.weights.gbWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.weights.eecWeight}}
+                            <p class="centered_data">
+                                <strong id="axle4_eecWeight">{{plateData.axles.axle4.weights.eecWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.weights.designWeight}}
+                            <p class="centered_data">
+                                <strong id="axle4_designWeight">{{plateData.axles.axle4.weights.designWeight}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="2" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.tyres.tyreSize}}
+                            <p class="centered_data">
+                                <strong id="axle4_tyreSize">{{plateData.axles.axle4.tyres.tyreSize}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td colspan="3" class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.tyres.plyRating}}
+                            <div class="ply_rating">
+                                <strong id="axle4_plyRating">{{plateData.axles.axle4.tyres.plyRating}}</strong>
+                            </div>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                    <td class="no_border_left_top axle_data">
+                        {{#if plateData.axles.axle4.tyres.fitmentCode}}
+                            <p class="centered_data">
+                                <strong id="axle4_fitmentCode">{{plateData.axles.axle4.tyres.fitmentCode}}</strong>
+                            </p>
+                        {{else}}
+                            <br/>
+                        {{/if}}
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="no_border_top max_kingpin">
+                        <p class="max_kingpin_title">
+                            <strong>Maximum Kingpin</strong>
+                        </p>
+                        <p class="max_kingpin_title">
+                            <strong>Load</strong>
+                        </p>
+                        <p class="max_kingpin_note">
+                            <span>(Semi-Trailers Only)</span>
+                        </p>
+                    </td>
+                    <td colspan="3" class="no_border_left_top align_top gray_box">
+                    </td>
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="max_load">
+                            <strong id="maxLoadOnCoupling">{{plateData.maxLoadOnCoupling}}</strong>
+                        </p>
+                    </td>
+                    <td colspan="6" class="no_border_left_top align_top">
+                        <p class="max_kingpin_title">
+                            *&rsquo;S&rsquo; indicates single wheels
+                        </p>
+                        <p class="max_kingpin_title">
+                            &lsquo;D&rsquo; indicates dual wheels
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="13" class="no_border_top align_top gray_box">
+                        <div class="bottom_gray_div">
+                            <div class="inline_elem">
+                                <div class="inline_elem_child empty_div_before_tyre_use">
+                                    {{#if (or (eq reissue.reason "Free replacement") (eq reissue.reason "Replacement"))}}
+                                        <p>
+                                            Replacement
+                                        </p>
+                                    {{/if}}
+                                </div>
+                                <div class="inline_elem_child tyre_use">
+                                    <p>
+                                        Tyre use conditions applicable to vehicle (See note 12)
+                                    </p>
+                                </div>
+                                <div class="inline_elem_child tyre_use_data">
+                                    <p id="tyreUseCode">
+                                        {{plateData.tyreUseCode}}
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="notifiable_alt">
+                                <p>NOTIFIABLE ALTERATIONS (Section 51 (1) (d) of the Road Traffic Act 1988)</p>
+                                <p class="notifiable_alt_following">
+                                    The following alterations in the vehicle or the equipment must
+                                    be notified to the Secretary of State. (See notes 9 to 11)
+                                </p>
+                                <p>(a) &nbsp; An alteration made in the structure or fixed equipment of the vehicle which
+                                    carries the carrying capacity or towing capacity of the vehicle;</p>
+                                <p>(b) &nbsp; An alteration, affecting any part of a braking system or the steering system with
+                                    which the vehicle is equipped or of the means of the operation of that system; of</p>
+                                <p>(c) &nbsp; Any other alteration made in the structure or fixed equipment of the vehicle which
+                                    renders or is likely to render the vehicle unsafe to travel on roads at any weight equal to
+                                    any weight shown in column (2) of the plating certificate.</p>
+                            </div>
+                            <div class="inline_elem bottom_details">
+                                <div class="inline_elem_child bottom_left_details">
+                                    <div class="inline_elem">
+                                        <div class="inline_elem_child test_station">
+                                            <p>Vehicle Testing Station No.</p>
+                                        </div>
+                                        <div class="inline_elem_child h999">
+                                            <p>H999</p>
+                                        </div>
+                                        <div class="inline_elem_child"></div>
+                                        <div class="inline_elem_child date_of_issue">
+                                            <p>Date of Issue</p>
+                                        </div>
+                                        <div class="inline_elem_child issue_date">
+                                            <p id="plateIssueDate">{{formatIsoDate plateData.plateIssueDate}}</p>
+                                        </div>
+                                    </div>
+                                    <div class="inline_elem black_square_container">
+                                        <div class="inline_elem_child align_middle black_square_padding">
+                                            <div class="black_square"></div>
+                                        </div>
+                                        <div class="inline_elem_child signature">
+                                            <p>Signature</p>
+                                        </div>
+                                        <div class="inline_elem_child signature_container">
+                                            <img class="signature_data" src="{{root}}/assets/images/plate-signature.png"
+                                                 alt="signature"
+                                                 height="28"/>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="inline_elem_child bottom_right_container">
+                                    <div class="bottom_right_text_container">
+                                        <p>
+                                            The plated weights and other plated particulars specified in this plating
+                                            certificate
+                                            are those determined for the vehicle concerned under Sections 49, 57 &amp; 58 of the
+                                            Road
+                                            Traffic Act 1988 and the Regulations made under these Sections
+                                            N.B. All weights in Kilograms &#8211; All Dimensions in Millimetres
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
         </td>
         <td class='gap'>
         </td>
         <td class='table-half'>
-        <table class="vtg6">
+            <table class="vtg6">
                 <tbody>
                 <tr>
                     <td colspan="4" rowspan="2" class="logo">
@@ -783,7 +816,7 @@
                             <p> Registration </p>
                         </div>
                         <div class="inline_elem_child align_middle">
-                            <span class="regn_date_data" id="regnDate">{{plateData.regnDate}}</span>
+                            <span class="regn_date_data" id="regnDate">{{formatIsoDate plateData.regnDate}}</span>
                         </div>
                     </td>
                     <td colspan="5" class="no_border_left_top manufacture_year">
@@ -827,15 +860,23 @@
                         </div>
                         <p class="weight_notes">(if higher than shown in column 2)</p>
                     </td>
-                    <td colspan="2" class="border_left border_top length_width gray_box">
+                    <td colspan="2" class="no_border_left_top length_width">
+                        <p class="centered_data"><strong>Length</strong></p>
                     </td>
-                    <td colspan="4" class="border_top border_right length_width gray_box">
+                    <td colspan="4" class="no_border_left_top length_width">
+                        <p class="centered_data"><strong>Width</strong></p>
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="2" class="border_left align_middle gray_box">
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="dimensionLength">{{plateData.dimensionLength}}</strong>
+                        </p>
                     </td>
-                    <td colspan="4" class="border_right align_middle gray_box">
+                    <td colspan="4" class="no_border_left_top align_middle">
+                        <p class="centered_data">
+                            <strong id="dimensionWidth">{{plateData.dimensionWidth}}</strong>
+                        </p>
                     </td>
                 </tr>
                 <tr>
@@ -862,11 +903,26 @@
                             <strong id="grossDesignWeight">{{plateData.grossDesignWeight}}</strong>
                         </p>
                     </td>
-                    <td colspan="2" class="border_left align_middle gray_box">
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <div class="coupling_foremost">
+                            <span>a. Coupling centre to vehicle foremost part (See note 6)</span>
+                        </div>
                     </td>
-                    <td colspan="2" class="no_border align_top gray_box">
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Max</strong>
+                            <p class="centered_data">
+                                <strong id="frontVehicleTo5thWheelCouplingMax">{{plateData.frontVehicleTo5thWheelCouplingMax}}</strong>
+                            </p>
+                        </div>
                     </td>
-                    <td colspan="2" class="border_right align_top gray_box">
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Min</strong>
+                            <p class="centered_data">
+                                <strong id="frontVehicleTo5thWheelCouplingMin">{{plateData.frontVehicleTo5thWheelCouplingMin}}</strong>
+                            </p>
+                        </div>
                     </td>
                 </tr>
                 <tr>
@@ -893,11 +949,26 @@
                             <strong id="trainDesignWeight">{{plateData.trainDesignWeight}}</strong>
                         </p>
                     </td>
-                    <td colspan="2" class="border_bottom border_left align_middle gray_box">
+                    <td colspan="2" class="no_border_left_top align_middle">
+                        <div class="coupling_rearmost">
+                            <span>b. Coupling centre to vehicle rearmost part (See note 7)</span>
+                        </div>
                     </td>
-                    <td colspan="2" class="border_bottom align_top gray_box">
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Max</strong>
+                            <p class="centered_data">
+                                <strong id="couplingCenterToRearTrlMax">{{plateData.couplingCenterToRearTrlMax}}</strong>
+                            </p>
+                        </div>
                     </td>
-                    <td colspan="2" class="border_right align_top gray_box">
+                    <td colspan="2" class="no_border_left_top align_top">
+                        <div class="centered_title coupling_max_min">
+                            <strong>Min</strong>
+                            <p class="centered_data">
+                                <strong id="couplingCenterToRearTrlMin">{{plateData.couplingCenterToRearTrlMin}}</strong>
+                            </p>
+                        </div>
                     </td>
                 </tr>
                 <tr>
@@ -921,8 +992,8 @@
                     </td>
                     <td colspan="2" class="no_border_left_top gray_box">
                     </td>
-                    <td colspan="6" rowspan="5" class="middle_right_section p-30">
-                        <div class="department_box w-175">
+                    <td colspan="6" rowspan="5" class="middle_right_section">
+                        <div class="department_box">
                             <div>
                                 <p class="centered_title middle_date_of_issue">
                                     <strong>Date of Issue</strong>
@@ -1181,6 +1252,58 @@
 
 <table>
     <td class='table-half'>
+        <div class="vtg6_secondPage">
+            <p class="vtg6_display">
+                DISPLAY OF MINISTRY PLATE
+            </p>
+            <ol>
+                <li>
+                    <p class="vtg6_securely_affixed">
+                        This plate must be securely affixed:-
+                    </p>
+                    <ol class="securely_affixed_options">
+                        <li>
+                            In the cab of the vehicle; or
+                        </li>
+                        <li>
+                            elsewhere on the vehicle if it is constructed without a cab (e.g. a trailer) in a conspicuous
+                            and readily accessible position and must be legible at all times (Regulation 70 of the Road
+                            Vehicle Construction and Use Regulations 1986).
+                        </li>
+                    </ol>
+                </li>
+            </ol>
+            <p class="vtg6_loss">
+                LOSS
+            </p>
+            <ol start="2">
+                <li>
+                    If this plate is lost or defaced, an application for a replacement may be made to:
+                </li>
+            </ol>
+            <div class="vtg6_dvsa">
+                <p>
+                    Driver and Vehicle Standards Agency (DVSA)
+                </p>
+                <p>
+                    Replacements Section
+                </p>
+                <p>
+                    Ellipse
+                </p>
+                <p>
+                    Padley Road
+                </p>
+                <p>
+                    Swansea, SA1 8AN
+                </p>
+                <p>
+                    A fee will be charged.
+                </p>
+            </div>
+        </div>
+    </td>
+    <td class='table-half'>
         <div class="secondPage">
             <p class="notes_title">NOTES</p>
             <p><strong>PLATED WEIGHTS</strong></p>
@@ -1298,58 +1421,6 @@
                 </li>
                 <li style="list-style-type: none;">(Rev April 2014)</li>
             </ol>
-        </div>
-    </td>
-    <td class='table-half'>
-        <div class="vtg6_secondPage">
-            <p class="vtg6_display">
-                DISPLAY OF MINISTRY PLATE
-            </p>
-            <ol>
-                <li>
-                    <p class="vtg6_securely_affixed">
-                        This plate must be securely affixed:-
-                    </p>
-                    <ol class="securely_affixed_options">
-                        <li>
-                            In the cab of the vehicle; or
-                        </li>
-                        <li>
-                            elsewhere on the vehicle if it is constructed without a cab (e.g. a trailer) in a conspicuous
-                            and readily accessible position and must be legible at all times (Regulation 70 of the Road
-                            Vehicle Construction and Use Regulations 1986).
-                        </li>
-                    </ol>
-                </li>
-            </ol>
-            <p class="vtg6_loss">
-                LOSS
-            </p>
-            <ol start="2">
-                <li>
-                    If this plate is lost or defaced, an application for a replacement may be made to:
-                </li>
-            </ol>
-            <div class="vtg6_dvsa">
-                <p>
-                    Driver and Vehicle Standards Agency (DVSA)
-                </p>
-                <p>
-                    Replacements Section
-                </p>
-                <p>
-                    Ellipse
-                </p>
-                <p>
-                    Padley Road
-                </p>
-                <p>
-                    Swansea, SA1 8AN
-                </p>
-                <p>
-                    A fee will be charged.
-                </p>
-            </div>
         </div>
     </td>
 </table>


### PR DESCRIPTION
## Description

- [CB2-7879](https://dvsa.atlassian.net/browse/CB2-7879) - Plates - Dimensions missing, and function code fix (INC0283807)
- [CB2-7880](https://dvsa.atlassian.net/browse/CB2-7880) - Plates - wording page swap left-right (INC0283784)
- [CB2-7890](https://dvsa.atlassian.net/browse/CB2-7890) - Plates - typo fix "Tyre Approval No." to "Type Approval No." (INC0283806)
- [CB2-7832](https://dvsa.atlassian.net/browse/CB2-7832) - Plates - EEC Maximum permitted weights should not be shown if "Coupling centre to rear axle maximum" is greater than 12,000

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
