### PR TITLE
fix(cb2-7978): plates - the notes information on the back is misaligned to the front

### DIFF
--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -811,3 +811,11 @@ width: 30px
 margin-top: .25em;
 margin-bottom: 0.25em;
 }
+
+.table-half-left {
+width: 57%
+}
+
+.table-width-right {
+width: 37%
+}

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -45,7 +45,7 @@ border:none;
 }
 
 .vtg6 {
-width: 535px;
+width:400px;
 height: 640px;
 border-collapse:collapse;
 border:none;
@@ -611,7 +611,7 @@ margin: auto;
 }
 
 .secondPage {
-max-width: 400px;
+width: 470px;
 height: 775px;
 margin-left: 10px;
 margin-right: 10px;

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -45,7 +45,7 @@ border:none;
 }
 
 .vtg6 {
-width: 400px;
+width: 535px;
 height: 640px;
 border-collapse:collapse;
 border:none;

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -750,7 +750,7 @@ width: 80%;
 }
 
 .vtg6_secondPage {
-width: 535px;
+width: 525px;
 height: 775px;
 margin-left: 10px;
 margin-right: 10px;

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -45,7 +45,7 @@ border:none;
 }
 
 .vtg6 {
-width:400px;
+width: 400px;
 height: 640px;
 border-collapse:collapse;
 border:none;
@@ -613,7 +613,6 @@ margin: auto;
 .secondPage {
 width: 500px;
 height: 775px;
-margin-left: 10px;
 margin-right: 10px;
 margin-top: 10px;
 font-size: 10px;

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -610,7 +610,7 @@ margin: auto;
 }
 
 .secondPage {
-width: 545px;
+max-width: 300px;
 height: 775px;
 margin-left: 10px;
 margin-right: 10px;

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -611,7 +611,7 @@ margin: auto;
 }
 
 .secondPage {
-width: 500px;
+width: 490px;
 height: 775px;
 margin-right: 10px;
 margin-top: 10px;
@@ -749,7 +749,7 @@ padding-left: 20px;
 width: 80%;
 }
 
-.vtg6_secondPage {
+.vtg7_secondPage {
 width: 525px;
 height: 775px;
 margin-left: 10px;
@@ -758,31 +758,31 @@ margin-top: 10px;
 font-size: 10px;
 }
 
-.vtg6_secondPage ol {
+.vtg7_secondPage ol {
 padding-left: 20px;
 padding-bottom: 10px;
 font-size: 15px;
 }
 
-.vtg6_secondPage li {
+.vtg7_secondPage li {
 padding-left: 10px;
 padding-bottom: 5px;
 }
 
-.vtg6_display {
+.vtg7_display {
 text-align: center;
 font-size: 15px;
 font-weight: bold;
 padding-bottom: 20px;
 }
 
-.vtg6_loss {
+.vtg7_loss {
 font-size: 15px;
 font-weight: bold;
 text-align: center;
 }
 
-.vtg6_securely_affixed {
+.vtg7_securely_affixed {
 padding-bottom: 5px;
 }
 
@@ -790,12 +790,12 @@ padding-bottom: 5px;
 list-style-type: lower-alpha;
 }
 
-.vtg6_dvsa {
+.vtg7_dvsa {
 font-size: 15px;
 padding-left: 8px;
 }
 
-.vtg6_dvsa p {
+.vtg7_dvsa p {
 padding-bottom: 10px;
 }
 

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -611,7 +611,7 @@ margin: auto;
 }
 
 .secondPage {
-width: 470px;
+width: 530px;
 height: 775px;
 margin-left: 10px;
 margin-right: 10px;

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -611,7 +611,7 @@ margin: auto;
 }
 
 .secondPage {
-width: 530px;
+width: 500px;
 height: 775px;
 margin-left: 10px;
 margin-right: 10px;

--- a/src/main/resources/assets/stylesheets/plates.hbs
+++ b/src/main/resources/assets/stylesheets/plates.hbs
@@ -49,6 +49,7 @@ width: 400px;
 height: 640px;
 border-collapse:collapse;
 border:none;
+padding-right: 2px;
 }
 
 .logo {
@@ -610,7 +611,7 @@ margin: auto;
 }
 
 .secondPage {
-max-width: 300px;
+max-width: 400px;
 height: 775px;
 margin-left: 10px;
 margin-right: 10px;
@@ -750,7 +751,7 @@ width: 80%;
 }
 
 .vtg6_secondPage {
-width: 470px;
+width: 535px;
 height: 775px;
 margin-left: 10px;
 margin-right: 10px;
@@ -810,12 +811,4 @@ width: 30px
 .secondPage > p, .secondPage > ol {
 margin-top: .25em;
 margin-bottom: 0.25em;
-}
-
-.table-half-left {
-width: 57%
-}
-
-.table-width-right {
-width: 37%
 }

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -1273,13 +1273,13 @@
 <div class="separatePage">
 <table>
     <td class='table-half'>
-        <div class="vtg6_secondPage">
-            <p class="vtg6_display">
+        <div class="vtg7_secondPage">
+            <p class="vtg7_display">
                 DISPLAY OF MINISTRY PLATE
             </p>
             <ol>
                 <li>
-                    <p class="vtg6_securely_affixed">
+                    <p class="vtg7_securely_affixed">
                         This plate must be securely affixed:-
                     </p>
                     <ol class="securely_affixed_options">
@@ -1294,7 +1294,7 @@
                     </ol>
                 </li>
             </ol>
-            <p class="vtg6_loss">
+            <p class="vtg7_loss">
                 LOSS
             </p>
             <ol start="2">
@@ -1302,7 +1302,7 @@
                     If this plate is lost or defaced, an application for a replacement may be made to:
                 </li>
             </ol>
-            <div class="vtg6_dvsa">
+            <div class="vtg7_dvsa">
                 <p>
                     Driver and Vehicle Standards Agency (DVSA)
                 </p>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -1272,7 +1272,7 @@
 </div>
 <div class="separatePage">
 <table>
-    <td class='table-half-left'>
+    <td class='table-half'>
         <div class="vtg6_secondPage">
             <p class="vtg6_display">
                 DISPLAY OF MINISTRY PLATE
@@ -1324,7 +1324,7 @@
             </div>
         </div>
     </td>
-    <td class='table-half-right'>
+    <td class='table-half'>
         <div class="secondPage">
             <p class="notes_title">NOTES</p>
             <p><strong>PLATED WEIGHTS</strong></p>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -1270,9 +1270,9 @@
         </td>
     </table>
 </div>
-
+<div class="separatePage">
 <table>
-    <td class='table-half'>
+    <td class='table-half-left'>
         <div class="vtg6_secondPage">
             <p class="vtg6_display">
                 DISPLAY OF MINISTRY PLATE
@@ -1324,7 +1324,7 @@
             </div>
         </div>
     </td>
-    <td class='table-half'>
+    <td class='table-half-right'>
         <div class="secondPage">
             <p class="notes_title">NOTES</p>
             <p><strong>PLATED WEIGHTS</strong></p>
@@ -1449,5 +1449,6 @@
         </div>
     </td>
 </table>
+</div>
 </body>
 </html>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7.hbs
@@ -1324,7 +1324,7 @@
             </div>
         </div>
     </td>
-    <td class='table-half-right'>
+    <td class='table-half'>
         <div class="secondPage">
             <p class="notes_title">NOTES</p>
             <p><strong>PLATED WEIGHTS</strong></p>

--- a/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG6_VTG7_TRL.hbs
@@ -1270,16 +1270,16 @@
         </td>
     </table>
 </div>
-
+<div class="separatePage">
 <table>
     <td class='table-half'>
-        <div class="vtg6_secondPage">
-            <p class="vtg6_display">
+        <div class="vtg7_secondPage">
+            <p class="vtg7_display">
                 DISPLAY OF MINISTRY PLATE
             </p>
             <ol>
                 <li>
-                    <p class="vtg6_securely_affixed">
+                    <p class="vtg7_securely_affixed">
                         This plate must be securely affixed:-
                     </p>
                     <ol class="securely_affixed_options">
@@ -1294,7 +1294,7 @@
                     </ol>
                 </li>
             </ol>
-            <p class="vtg6_loss">
+            <p class="vtg7_loss">
                 LOSS
             </p>
             <ol start="2">
@@ -1302,7 +1302,7 @@
                     If this plate is lost or defaced, an application for a replacement may be made to:
                 </li>
             </ol>
-            <div class="vtg6_dvsa">
+            <div class="vtg7_dvsa">
                 <p>
                     Driver and Vehicle Standards Agency (DVSA)
                 </p>
@@ -1449,5 +1449,6 @@
         </div>
     </td>
 </table>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Fix CB2-7978:

When printing plates for Trailers, the information on the back of the plate is misaligned.

This PR also changes the names on some of the classes from VTG6 to VTG7 as the elements are actually on the back of the VTG7 plate.