### PR TITLE
CB2-9558: updated no data available, km and mi translations

### DIFF
--- a/src/main/java/uk/gov/dvsa/view/cvs/CvsOdometerReadingFormatter.java
+++ b/src/main/java/uk/gov/dvsa/view/cvs/CvsOdometerReadingFormatter.java
@@ -11,7 +11,7 @@ public class CvsOdometerReadingFormatter {
     public static final String MILES_WELSH = "milltiroedd";
     private static final String MILES_UNIT = "mi";
     public static final String KILOMETERS = "kilometres";
-    public static final String KILOMETERS_WELSH = "cilomedr";
+    public static final String KILOMETERS_WELSH = "cilometrau";
     private static final String KILOMETERS_UNIT = "km";
     private static final String THOUSANDS_PATTERN = "\\B(?=(?:.{3})+$)";
     private static final String THOUSANDS_SEPARATOR = ",";

--- a/src/main/java/uk/gov/dvsa/view/cvs/CvsOdometerReadingFormatter.java
+++ b/src/main/java/uk/gov/dvsa/view/cvs/CvsOdometerReadingFormatter.java
@@ -10,8 +10,8 @@ public class CvsOdometerReadingFormatter {
     public static final String MILES = "miles";
     public static final String MILES_WELSH = "milltiroedd";
     private static final String MILES_UNIT = "mi";
-    public static final String KILOMETER = "kilometres";
-    public static final String KILOMETER_WELSH = "cilomedr";
+    public static final String KILOMETERS = "kilometres";
+    public static final String KILOMETERS_WELSH = "cilomedr";
     private static final String KILOMETERS_UNIT = "km";
     private static final String THOUSANDS_PATTERN = "\\B(?=(?:.{3})+$)";
     private static final String THOUSANDS_SEPARATOR = ",";
@@ -51,9 +51,9 @@ public class CvsOdometerReadingFormatter {
             case MILES:
             case MILES_UNIT:
                 return unitWelsh.equals(Boolean.TRUE) ? MILES_WELSH : MILES;
-            case KILOMETER:
+            case KILOMETERS:
             case KILOMETERS_UNIT:
-                return unitWelsh.equals(Boolean.TRUE) ? KILOMETER_WELSH : KILOMETER;
+                return unitWelsh.equals(Boolean.TRUE) ? KILOMETERS_WELSH : KILOMETERS;
             default:
                 return unit;
         }

--- a/src/main/java/uk/gov/dvsa/view/cvs/CvsOdometerReadingFormatter.java
+++ b/src/main/java/uk/gov/dvsa/view/cvs/CvsOdometerReadingFormatter.java
@@ -9,8 +9,9 @@ public class CvsOdometerReadingFormatter {
 
     public static final String MILES = "miles";
     public static final String MILES_WELSH = "milltiroedd";
-
     private static final String MILES_UNIT = "mi";
+    public static final String KILOMETER = "kilometres";
+    public static final String KILOMETER_WELSH = "cilomedr";
     private static final String KILOMETERS_UNIT = "km";
     private static final String THOUSANDS_PATTERN = "\\B(?=(?:.{3})+$)";
     private static final String THOUSANDS_SEPARATOR = ",";
@@ -47,10 +48,12 @@ public class CvsOdometerReadingFormatter {
 
     private String formatUnit(String unit, Boolean unitWelsh) {
         switch (unit) {
+            case MILES:
             case MILES_UNIT:
                 return unitWelsh.equals(Boolean.TRUE) ? MILES_WELSH : MILES;
+            case KILOMETER:
             case KILOMETERS_UNIT:
-                return "km";
+                return unitWelsh.equals(Boolean.TRUE) ? KILOMETER_WELSH : KILOMETER;
             default:
                 return unit;
         }

--- a/src/main/resources/views/CommercialVehicles/passNoSeatbeltFieldsWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/passNoSeatbeltFieldsWelsh.hbs
@@ -268,7 +268,7 @@
                                 </ul>
                                 {{else}}
                                     <span class="heading-info__content" id="no_data_message">
-                                        No data available
+                                        Dim data ar gael
                                     </span>
                                 {{/if}}
                                 <!-- /header__histories -->

--- a/src/main/resources/views/CommercialVehicles/passWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/passWelsh.hbs
@@ -245,7 +245,7 @@
                                 </ul>
                                 {{else}}
                                     <span class="heading-info__content" id="no_data_message">
-                                        No data available
+                                        Dim data ar gael
                                     </span>
                                 {{/if}}
                                 <!-- /header__histories -->

--- a/src/test/java/htmlverification/tests/CvsHgvPassBilingualTest.java
+++ b/src/test/java/htmlverification/tests/CvsHgvPassBilingualTest.java
@@ -101,7 +101,7 @@ public class CvsHgvPassBilingualTest {
         String mileage2 = certificatePageObjectVTG5W.getMileage();
 
         assertEquals(testCertificate.getData().getFormattedCurrentOdometer(), mileage);
-        assertEquals("20,000 cilomedr", mileage2);
+        assertEquals("20,000 cilometrau", mileage2);
     }
 
     @Test

--- a/src/test/java/htmlverification/tests/CvsHgvPassBilingualTest.java
+++ b/src/test/java/htmlverification/tests/CvsHgvPassBilingualTest.java
@@ -101,7 +101,7 @@ public class CvsHgvPassBilingualTest {
         String mileage2 = certificatePageObjectVTG5W.getMileage();
 
         assertEquals(testCertificate.getData().getFormattedCurrentOdometer(), mileage);
-        assertEquals(testCertificate.getData().getFormattedCurrentOdometer(), mileage2);
+        assertEquals("20,000 cilomedr", mileage2);
     }
 
     @Test

--- a/src/test/java/htmlverification/tests/VTP20Test.java
+++ b/src/test/java/htmlverification/tests/VTP20Test.java
@@ -176,7 +176,7 @@ public class VTP20Test {
     @Test
     public void verifyOdomoterHistory() {
         String actual = certificatePageObject.getElement("#mileage-history").text();
-        String expected = "120 km 01.02.2016 330 km 30.01.2017";
+        String expected = "120 kilometres 01.02.2016 330 kilometres 30.01.2017";
         assertEquals(expected, actual);
     }
 

--- a/src/test/java/htmlverification/tests/VTP20WTest.java
+++ b/src/test/java/htmlverification/tests/VTP20WTest.java
@@ -152,7 +152,7 @@ public class VTP20WTest {
         certificatePageObject = new CertificatePageObject(certHtml);
 
         String actual = certificatePageObject.getElement("#no_data_message").text();
-        String expected = "No data available";
+        String expected = "Dim data ar gael";
         assertEquals(expected, actual);
     }
 }

--- a/src/test/java/uk/gov/dvsa/view/cvs/CvsOdometerReadingFormatterTest.java
+++ b/src/test/java/uk/gov/dvsa/view/cvs/CvsOdometerReadingFormatterTest.java
@@ -26,7 +26,7 @@ public class CvsOdometerReadingFormatterTest {
                 {
                         "format in kilometers",
                         new CvsOdometerReading("15012", "km", "01.12.2017"),
-                        "15,012 km"
+                        "15,012 kilometres"
                 },
                 {
                         "format without unit",


### PR DESCRIPTION
## CB2-9558/9559: Update Translations

This PR includes the changes for both CB2-9558 (translate wording of mi/miles and km/kilometres to Welsh word equivalent) and CB2-9559 (translate No data found to Welsh equivalent).

Related issue: [CB2-9558](https://dvsa.atlassian.net/browse/CB2-9558)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
