### PR TITLE
CB2-10687: Update Doc-Gen to Generate IVA30 Certificate

### DIFF
--- a/src/main/java/uk/gov/dvsa/model/cvs/IVA30.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/IVA30.java
@@ -3,17 +3,34 @@ package uk.gov.dvsa.model.cvs;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.dvsa.model.Document;
+import uk.gov.dvsa.model.cvs.certificateData.IvaFailCertificateData;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class IVA30 extends Document {
-    @JsonProperty("dummyProperty")
-    private String dummyProperty;
+    @JsonProperty("ID")
+    private String id;
 
-    public String getDummyProperty() {
-        return dummyProperty;
+    @JsonProperty("IVA_DATA")
+    private IvaFailCertificateData ivaData;
+
+    public IVA30() {
+        // zero value constructor
     }
-    public IVA30 setDummyProperty(String dummyProperty) {
-        this.dummyProperty = dummyProperty;
+
+    public String getId() {
+        return id;
+    }
+
+    public IVA30 setId(String id) {
+        this.id = id;
         return this;
+    }
+
+    public IvaFailCertificateData getIvaData() {
+        return ivaData;
+    }
+
+    public void setIvaData(IvaFailCertificateData ivaData) {
+        this.ivaData = ivaData;
     }
 }

--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/AdditionalDefect.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/AdditionalDefect.java
@@ -1,0 +1,37 @@
+package uk.gov.dvsa.model.cvs.certificateData;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AdditionalDefect {
+    @JsonProperty
+    private String defectName;
+    @JsonProperty
+    private String defectNotes;
+
+    public AdditionalDefect(String defectName, String defectNotes) {
+        this.defectName = defectName;
+        this.defectNotes = defectNotes;
+    }
+
+    public AdditionalDefect() {
+        // zero value constructor
+    }
+
+    public String getDefectName() {
+        return defectName;
+    }
+
+    public void setDefectName(String defectName) {
+        this.defectName = defectName;
+    }
+
+    public String getDefectNotes() {
+        return defectNotes;
+    }
+
+    public void setDefectNotes(String defectNotes) {
+        this.defectNotes = defectNotes;
+    }
+}

--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/IvaFailCertificateData.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/IvaFailCertificateData.java
@@ -1,0 +1,148 @@
+package uk.gov.dvsa.model.cvs.certificateData;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IvaFailCertificateData {
+    @JsonProperty("serialNumber")
+    private String serialNo;
+    @JsonProperty("vehicleTrailerNrNo")
+    private String vehicleTrailerNrNo;
+    @JsonProperty("testCategoryClass")
+    private String testCategoryClass;
+    @JsonProperty("vin")
+    private String vin;
+    @JsonProperty("testCategoryBasicNormal")
+    private String testCategoryBasicNormal;
+    @JsonProperty("make")
+    private String make;
+    @JsonProperty("model")
+    private String model;
+    @JsonProperty("bodyType")
+    private String bodyType;
+    @JsonProperty("date")
+    private String date;
+    @JsonProperty("reapplicationDate")
+    private String reapplicationDate;
+    @JsonProperty("station")
+    private String station;
+    @JsonProperty("testerName")
+    private String testerName;
+    @JsonProperty("additionalDefects")
+    private AdditionalDefect[] additionalDefects;
+    @JsonProperty("requiredStandards")
+    private RequiredStandard[] requiredStandards;
+
+    public String getSerialNo() {
+        return serialNo;
+    }
+
+    public void setSerialNo(String serialNo) {
+        this.serialNo = serialNo;
+    }
+
+    public String getVehicleTrailerNrNo() {
+        return vehicleTrailerNrNo;
+    }
+
+    public void setVehicleTrailerNrNo(String vehicleTrailerNrNo) {
+        this.vehicleTrailerNrNo = vehicleTrailerNrNo;
+    }
+
+    public String getTestCategoryClass() {
+        return testCategoryClass;
+    }
+
+    public void setTestCategoryClass(String testCategoryClass) {
+        this.testCategoryClass = testCategoryClass;
+    }
+
+    public String getVin() {
+        return vin;
+    }
+
+    public void setVin(String vin) {
+        this.vin = vin;
+    }
+
+    public String getTestCategoryBasicNormal() {
+        return testCategoryBasicNormal;
+    }
+
+    public void setTestCategoryBasicNormal(String testCategoryBasicNormal) {
+        this.testCategoryBasicNormal = testCategoryBasicNormal;
+    }
+
+    public String getMake() {
+        return make;
+    }
+
+    public void setMake(String make) {
+        this.make = make;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getBodyType() {
+        return bodyType;
+    }
+
+    public void setBodyType(String bodyType) {
+        this.bodyType = bodyType;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public String getReapplicationDate() {
+        return reapplicationDate;
+    }
+
+    public void setReapplicationDate(String reapplicationDate) {
+        this.reapplicationDate = reapplicationDate;
+    }
+
+    public String getStation() {
+        return station;
+    }
+
+    public void setStation(String station) {
+        this.station = station;
+    }
+
+    public String getTesterName() {
+        return testerName;
+    }
+
+    public void setTesterName(String testerName) {
+        this.testerName = testerName;
+    }
+
+    public AdditionalDefect[] getAdditionalDefects() {
+        return additionalDefects;
+    }
+
+    public void setAdditionalDefects(AdditionalDefect[] additionalDefects) {
+        this.additionalDefects = additionalDefects;
+    }
+
+    public RequiredStandard[] getRequiredStandards() {
+        return requiredStandards;
+    }
+
+    public void setRequiredStandards(RequiredStandard[] requiredStandards) {
+        this.requiredStandards = requiredStandards;
+    }
+}

--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/RequiredStandard.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/RequiredStandard.java
@@ -1,0 +1,114 @@
+package uk.gov.dvsa.model.cvs.certificateData;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RequiredStandard {
+    @JsonProperty
+    private boolean prs;
+    @JsonProperty
+    private String requiredStandard;
+    @JsonProperty
+    private String refCalculation;
+    @JsonProperty
+    private String sectionNumber;
+    @JsonProperty
+    private boolean additionalInfo;
+    @JsonProperty
+    private String sectionDescription;
+    @JsonProperty
+    private int rsNumber;
+    @JsonProperty
+    private String[] inspectionTypes;
+    @JsonProperty
+    private String additionalNotes;
+
+    public RequiredStandard(boolean prs, String requiredStandard, String refCalculation, String sectionNumber, boolean additionalInfo, String sectionDescription, int rsNumber, String[] inspectionTypes, String additionalNotes) {
+        this.prs = prs;
+        this.requiredStandard = requiredStandard;
+        this.refCalculation = refCalculation;
+        this.sectionNumber = sectionNumber;
+        this.additionalInfo = additionalInfo;
+        this.sectionDescription = sectionDescription;
+        this.rsNumber = rsNumber;
+        this.inspectionTypes = inspectionTypes;
+        this.additionalNotes = additionalNotes;
+    }
+
+    public RequiredStandard() {
+        // zero value constructor
+    }
+
+    public boolean getPrs() {
+        return prs;
+    }
+
+    public void setPrs(boolean prs) {
+        this.prs = prs;
+    }
+
+    public String getRequiredStandard() {
+        return requiredStandard;
+    }
+
+    public void setRequiredStandard(String requiredStandard) {
+        this.requiredStandard = requiredStandard;
+    }
+
+    public String getRefCalculation() {
+        return refCalculation;
+    }
+
+    public void setRefCalculation(String refCalculation) {
+        this.refCalculation = refCalculation;
+    }
+
+    public String getSectionNumber() {
+        return sectionNumber;
+    }
+
+    public void setSectionNumber(String sectionNumber) {
+        this.sectionNumber = sectionNumber;
+    }
+
+    public boolean getAdditionalInfo() {
+        return additionalInfo;
+    }
+
+    public void setAdditionalInfo(boolean additionalInfo) {
+        this.additionalInfo = additionalInfo;
+    }
+
+    public String getSectionDescription() {
+        return sectionDescription;
+    }
+
+    public void setSectionDescription(String sectionDescription) {
+        this.sectionDescription = sectionDescription;
+    }
+
+    public int getRsNumber() {
+        return rsNumber;
+    }
+
+    public void setRsNumber(int rsNumber) {
+        this.rsNumber = rsNumber;
+    }
+
+    public String[] getInspectionTypes() {
+        return inspectionTypes;
+    }
+
+    public void setInspectionTypes(String[] inspectionTypes) {
+        this.inspectionTypes = inspectionTypes;
+    }
+
+    public String getAdditionalNotes() {
+        return additionalNotes;
+    }
+
+    public void setAdditionalNotes(String additionalNotes) {
+        this.additionalNotes = additionalNotes;
+    }
+}

--- a/src/main/resources/assets/stylesheets/iva-30.hbs
+++ b/src/main/resources/assets/stylesheets/iva-30.hbs
@@ -147,6 +147,23 @@ margin-top: 0px;
 padding-top: 0px;
 list-style-type: none;
 }
+
+.required-standard-list {
+list-style-type: none;
+}
+
+.additional-defect-list {
+list-style-type: none;
+}
+
+.required-standard-section {
+text-transform:uppercase;
+}
+
+.test-category-value {
+text-transform:uppercase;
+}
+
 .item-list {
 margin-left: 50px;
 margin-bottom: 0px;

--- a/src/main/resources/assets/stylesheets/iva-30.hbs
+++ b/src/main/resources/assets/stylesheets/iva-30.hbs
@@ -1,8 +1,26 @@
 
-@page {
+@page{
 size: A4 portrait;
-margin: 20px 24px 0 24px;
-padding: 0;
+margin: 1cm 1cm 1cm 1cm;
+@bottom-left {
+content: element(footer-left);
+}
+@bottom-center {
+content: element(footer-mid);
+}
+@bottom-right {
+content: element(footer-right);
+}
+}
+
+@page :first{
+margin-top: 35mm;
+@top-left{
+content: element(first-page-header-left);
+}
+@top-right{
+content: element(first-page-header-right);
+}
 }
 
 p { margin:5px; }
@@ -26,6 +44,19 @@ page-break-inside: avoid;
 font-size: 90%;
 }
 
+#cert-subtitle{
+margin-top: 0;
+font-size: 85%;
+}
+
+.separate-page{
+page-break-after: always;
+}
+
+#back-page{
+page-break-after: avoid;
+}
+
 *,
 :after,
 :before {
@@ -33,24 +64,26 @@ box-sizing: border-box;
 line-height: 1;
 }
 
-.separate-page {
-page-break-after: always;
-}
 .section-border {
 border-style: solid;
-border-color: black grey grey grey;
+border-color: black;
 margin-bottom: 5px;
 }
 
 .section-title-border {
 border-style: solid;
+border-width: 1px;
 border-color: black;
-background-color: grey;
+background-color: #d0d0d0;
 font-weight:bold;
 text-align: center;
-margin-left: -3px;
-margin-top: -2px;
-width: 100.7%;
+margin-top: -1px;
+margin-left: -1px;
+width: 100.3%;
+}
+
+#cert-title-border{
+margin-top: 0px;
 }
 
 .section-title-border h1 {
@@ -76,20 +109,29 @@ float: right;
 width: 50%;
 }
 
-.footer {
-width: 100%;
+
+.footer-left {
+position: running(footer-left);
 }
 
-#footer-left {
-float: left;
-text-align: left;
-width: 50%;
+.footer-mid {
+position: running(footer-mid);
+text-align: center;
 }
 
-#footer-right {
-float: right;
+.footer-current-page-number:before{
+content: counter(page);
+font-weight: bold;
+}
+
+.footer-total-page-count:before{
+content: counter(pages);
+font-weight: bold;
+}
+
+.footer-right {
 text-align: right;
-width: 40%;
+position: running(footer-right);
 }
 
 #no-margin-p {
@@ -97,7 +139,7 @@ margin: 0px;
 }
 
 .bold-title {
-font-size: 1.5em;
+font-size: 1.25em;
 }
 
 .vehicle-section-list {
@@ -121,4 +163,73 @@ clear: both;
 .refusal-list p {
 margin: 0px;
 clear: both;
+}
+
+.first-page-header-left {
+margin-top: 50px;
+position: running(first-page-header-left);
+padding-bottom: 0px;
+margin-bottom: 5px;
+}
+.first-page-header-right{
+margin-top: 50px;
+position: running(first-page-header-right);
+padding-left: 350px;
+padding-bottom: 0px;
+margin-bottom: 5px;
+}
+
+#defect-details-subtitle-border {
+background-color: white;
+}
+
+.header-serial-no {
+width: 250px;
+border-style: solid;
+border-width: 1px;
+}
+
+.header-serial-no-title {
+padding: 2px;
+margin-bottom: 0px;
+}
+
+.header-pagination {
+width: 109px;
+border-style: solid;
+border-width: 1px;
+padding-left: 1em;
+padding-right: 1em;
+padding-top: 2em;
+padding-bottom: 2em;
+margin-top: -1px;
+}
+
+#header-pagination-num:before{
+content: counter(pages);
+}
+
+.table {
+width: 100%;
+border-collapse: collapse;
+margin-bottom: 1em;
+table-layout: auto;
+}
+
+.table-row-cell {
+border-style: solid;
+border-width: 1px;
+padding-bottom: 0.25em;
+width: 50%;
+vertical-align: middle;
+font-size: 92%;
+}
+
+.no-border-cell{
+border: none;
+}
+
+#appointment-text{
+text-align: center;
+font-size: 85%;
 }

--- a/src/main/resources/views/CommercialVehicles/IVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/IVA30.hbs
@@ -1,131 +1,239 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
-    <head>
-        <title>IVA30</title>
-        <style type="text/css" media="print, screen">
-           {{~> assets/stylesheets/iva-30 this}}
-       </style>
-    </head>
+<head>
+    <title>IVA30</title>
+    <style type="text/css" media="print, screen">
+        {{~> assets/stylesheets/iva-30 this}}
+    </style>
+</head>
 
-
-    <body>
-    <div class="separate-page">
-        <!-- first box -->
-        <div class="section-border">
-            <div class="section-title-border">
-                <h1>RE-EXAMINATION</h1>
-            </div>
-            <div class="section-text-wrapper">
-                <p> This notification indicates the items of non-compliance being the reason(s)
-                    why an Individual Approval Certificate (IAC) has not been issued. An application
-                    for re-examination can be made up to 6 calendar months following the issue date
-                    of the first "Notification of Refusal" in respect of the original application.
-                    In any other case, a new application and a full fee must be submitted.</p>
-                <p> When modification/rectification has been completed, or additional evidence of
-                    compliance obtained, an application for a re-examination (verbally or in writing)
-                    should be made, in the case of an M1 or N1 vehicle class listed below, to attend at the test
-                    station that issued this notification and in respect of any other class or category, to
-                    the test station of your choice. To obtain a re-examination appointment please contact <strong>(0300) 200 1188</strong> </p>
-
-                <div class="exam-list">
-                    <ul id="left-exam-list">
-                        <li>Amateur Built Vehicle</li>
-                        <li>Rebuilt Vehicle</li>
-                        <li>Motor Ambulance</li>
-                        <li>Motor Caravan</li>
-                        <li>Vehicle manufactured using parts of a registered vehicle</li>
-                    </ul>
-
-                    <ul id="right-exam-list">
-                        <li>Disabled Person's Vehicle</li>
-                        <li>Hearse</li>
-                        <li>Armoured Vehicle</li>
-                        <li>Vehicle manufactured in very low volume</li>
-                    </ul>
-                </div>
-
-                <div class="refusal-list">
-                    <p> Where a "Notification of Refusal" is issued, a further examination (a retest) will be carried
-                        out without further payment if: </p>
-                    <p> - the vehicle is submitted for the examination at the place where it was previously examined, and</p>
-                    <p> - the vehicle is submitted for examination before the end of the fifth day on which DVSA is accepting
-                        vehicles for inspection following the day of the original examination, and</p>
-                    <p> - in the case of any vehicle category, the application is due to a failure to provide sufficient
-                        documentary evidence before the examination to demonstrate compliance, or</p>
-                    <p> - in the case of an M1 or N1 category vehicle only, failure is due to one or more of the following
-                        items (subject to a maximum of six items)</p>
-                </div>
-
-                <ul class="item-list">
-                    <li>Item 3           Fuel tanks/rear protective devices - fuel filler arrangements only;</li>
-                    <li>Item 4           Rear registration plate space - all requirements;</li>
-                    <li>Item 7           Audible warning - operation of audible warning device only;</li>
-                    <li>Item 8           Indirect vision - all except field of view;</li>
-                    <li>Item 9           Braking - warning lamps only;</li>
-                    <li>Item 10         EMC - markings only;</li>
-                    <li>Item 12         Interior fittings - no more than 3 separate examples of failure to comply;</li>
-                    <li>Item 13         Anti-theft &amp; immobiliser - all requirements;</li>
-                    <li>Item 16         Exterior projections - no more than 3 separate examples of failure to comply;</li>
-                    <li>Item 17         Speedometer - illumination only;</li>
-                    <li>Item 18         Plates - all requirements;</li>
-                    <li>Item 20-30    Lighting - all except angle of visibility and position;</li>
-                    <li>Item 31         Seat belts - child restraint warning label only;</li>
-                    <li>Item 33         Controls - no more than 3 separate examples of failure to comply;</li>
-                    <li>Item 34         Defrost/demist - all requirements;</li>
-                    <li>Item 35         Wash/wipe - all requirements;</li>
-                    <li>Item 36         Heating - all requirements;</li>
-                    <li>Item 37         Wheel guards - all requirements;</li>
-                    <li>Item 45         Safety glass - approval marking only;</li>
-                    <li>Item 46         Tyres - approval marking, one example only;</li>
-
-                </ul>
-            </div>
+<body>
+<!-- FIRST PAGE HEADER -->
+<div class="first-page-header-left">
+    <div class="header-serial-no">
+        <div class="header-serial-no-title">
+            <span> <b>Serial Number: </b> <!-- Put Serial Number data here --> </span>
         </div>
-        <!-- second box -->
-        <div class="section-border">
-            <div class="section-title-border">
-                <h1>USE OF THE VEHICLE</h1>
-            </div>
-            <div class="section-text-wrapper">
-                <p id="no-margin-p">It is an offence to use a vehicle that requires type approval without an Individual Approval
-                    Certificate confirming compliance with the type approval requirements, except for the purposes of:</p>
-                <ul class="vehicle-section-list">
-                    <li> - submitting it, by previous arrangement, for an approval examination;</li>
-                    <li> - bringing it away from such an examination;</li>
-                    <li> - delivering it, by previous arrangement, to a place where relevant work is to be done on it following
-                        receipt of a refusal to issue an Individual Approval Certificate;</li>
-                    <li> - bringing it away from a place where relevant work has been done on it.</li>
-                </ul>
-                <p>You may have been notified of defects in addition to those appertaining to the approval requirements.
-                    Even in the above circumstances you may be committing an offence if you use the vehicle, and it does
-                    not comply with the various regulations relating to its construction and use.</p>
-            </div>
+    </div>
+    <div class="header-pagination">
+        <span>Page 1 of</span>
+        <span id ="header-pagination-num"></span>
+    </div>
+</div>
+<div class="first-page-header-right">
+    <img src="{{root}}/assets/images/dvsa_crest.png" alt="logo" width="110"/>
+</div>
+
+<!-- footer for all pages -->
+<div class="footer-left">
+    <p> <b class="bold-title">IVA30VTA (DVSA0842) </b> </p>
+</div>
+<div class = "footer-mid">
+    <span class="footer-current-page-number"></span>
+    <span class="footer__bottom-page-counter-text"><b>of</b></span>
+    <span class="footer-total-page-count"></span>
+</div>
+<div class = "footer-right">
+    <p><b>Version 1.0 Apr 2024</b></p>
+</div>
+
+<!-- first page -->
+<div class="separate-page">
+    <div class="section-title-border" id ='cert-title-border'>
+        <h1> INDIVIDUAL VEHICLE APPROVAL (IVA)</h1>
+        <h1> NOTIFICATION OF REFUSAL TO ISSUE AN INDIVIDUAL APPROVAL CERTIFICATE </h1>
+        <p id="cert-subtitle"><b>The Road Vehicles (Approval) Regulations 2020</b></p>
+    </div>
+
+    <p id = "appointment-text"> AN APPOINTMENT FOR RE-EXAMINATION <b>CANNOT</b> BE MADE ON THE DAY ON WHICH THIS EXAMINATION WAS CARRIED OUT
+        PLEASE CONTACT <b> (0300) 200 1188 </b> TO MAKE AN APPOINTMENT QUOTING YOUR TAS REFERENCE NUMBER </p>
+
+    <!--- Vehicle details section -->
+    <table class="table">
+        <thead>
+        <th scope="row" colspan="2" class="section-title-border">
+            <h1> VEHICLE DETAILS </h1>
+        </th>
+        </thead>
+        <tr class="table-row-cell">
+            <td class="table-row-cell"><b>Vehicle/Trailer NR No: </b> <!--Put data here --> </td>
+            <td class="table-row-cell"><b>Test Category: </b> <!--Put data here --> </td>
+        </tr>
+        <tr class="table-row-cell">
+            <td class="table-row-cell"><b>Make/Model: </b> <!--Put data here --> </td>
+            <td class="table-row-cell"><b>VIN/Chassis No: </b> <!--Put data here --> </td>
+        </tr>
+        <tr class="table-row-cell">
+            <td class="table-row-cell"> <b>Body Type: </b> <!--Put data here --> </td>
+            <td class = "no-border-cell"></td>
+        </tr>
+    </table>
+
+    <!-- Required Standards Not Met Section -->
+    <div class="section-border">
+        <div class="section-title-border">
+            <h1> DEFECT DETAILS </h1>
         </div>
-
-        <!-- third box -->
-        <div class="section-border">
-            <div class="section-title-border">
-                <h1>YOUR RIGHT TO APPEAL</h1>
-            </div>
-            <div class="section-text-wrapper">
-
-                <p>If you do not agree with the refusal to issue an Individual Approval Certificate, you may appeal. If you
-                    wish to appeal against all or any of the grounds for refusal you must complete form IVA17 which is
-                    available from the test location or from the gov.uk website <strong>www.gov.uk/vehicleapproval</strong>. The form, together
-                    with the appropriate fee, must be received at the Vehicle Approvals Section, DVSA, Ellipse, Padley
-                    Road, Swansea, SA1 8AN within 14 days of the date the original notification of refusal was issued.</p>
-
-                <p>It is important that no modification/rectification work carried out on the vehicle before the appeal
-                    test as this may affect the outcome of the appeal.</p>
-            </div>
+        <div class="section-title-border" id="defect-details-subtitle-border">
+            <h1> Required Standard(s) Not Met: </h1>
         </div>
-
-        <!-- footer -->
-        <div class="footer">
-            <p id="footer-left"> <strong class="bold-title">IVA 30E</strong> (DVSA 0211) </p>
-            <p id="footer-right"> Version 2.3 (30/11/2022) </p>
+        <div class="section-text-wrapper">
+            <!-- List incoming defects here -->
         </div>
     </div>
 
-    </body>
+    <p> I hereby refuse an Individual Approval Certificate in respect of the above described vehicle on the
+        grounds that the vehicle fails to comply with the relevant requirements prescribed under The Road Vehicles
+        (Approval) Regulations 2020 </p>
+
+    <!--- Signature Section --->
+    <table class="table">
+        <tr>
+            <td></td>
+            <td class="table-row-cell"> <b>Reapplication required by: </b> <!--Put data here --> </td>
+        </tr>
+        <tr>
+            <td class="table-row-cell"> <b>Signed: </b> <!--Put data here --> </td>
+            <td class="table-row-cell"> <b>Date: </b>  <!--Put data here --> </td>
+        </tr>
+        <tr>
+            <td class="table-row-cell"> <b>Name: </b> <!--Put data here --> </td>
+            <td class="table-row-cell"> <b>Station: </b> <!--Put data here --> </td>
+        </tr>
+        <tr>
+            <td class="table-row-cell" colspan="2"> <p><b>The following additional defects may result in the vehicle not complying with the requirements
+                of The Road Vehicles (Construction and Use) Regulations 1986. (See notes overleaf) </b></p>
+                <p> N/A </p>
+                <!-- Put AdditionalDefects here -->
+            </td>
+        </tr>
+    </table>
+
+
+    <!-- Data Protection Section -->
+    <div class="section-border">
+        <div class="section-title-border">
+            <h1> DATA PROTECTION STATEMENT 2019 </h1>
+        </div>
+        <div class="section-text-wrapper">
+            <p> <b>DATA PROTECTION</b> - We collect and store your personal data so that we can provide you with a
+                notification of refusal to issue an Individual Approval Certificate (IAC). </p>
+            <p> We may share your personal data if we have a lawful reason. For example, as part of a criminal
+                investigation or to prevent fraud. Find out more at <a href="www.gov.uk/dvsa/privacy">www.gov.uk/dvsa/privacy</a></p>
+        </div>
+    </div>
+</div>
+
+<!-- back-page -->
+<div class="separate-page" id="back-page">
+    <!-- first box -->
+    <div class="section-border">
+        <div class="section-title-border">
+            <h1>RE-EXAMINATION</h1>
+        </div>
+        <div class="section-text-wrapper">
+            <p> This notification indicates the items of non-compliance being the reason(s)
+                why an Individual Approval Certificate (IAC) has not been issued. An application
+                for re-examination can be made up to 6 calendar months following the issue date
+                of the first "Notification of Refusal" in respect of the original application.
+                In any other case, a new application and a full fee must be submitted.</p>
+            <p> When modification/rectification has been completed, or additional evidence of
+                compliance obtained, an application for a re-examination (verbally or in writing)
+                should be made, in the case of an M1 or N1 vehicle class listed below, to attend at the test
+                station that issued this notification and in respect of any other class or category, to
+                the test station of your choice. To obtain a re-examination appointment please contact <strong>(0300) 200 1188</strong> </p>
+
+            <div class="exam-list">
+                <ul id="left-exam-list">
+                    <li>Amateur Built Vehicle</li>
+                    <li>Rebuilt Vehicle</li>
+                    <li>Motor Ambulance</li>
+                    <li>Motor Caravan</li>
+                    <li>Vehicle manufactured using parts of a registered vehicle</li>
+                </ul>
+
+                <ul id="right-exam-list">
+                    <li>Disabled Person's Vehicle</li>
+                    <li>Hearse</li>
+                    <li>Armoured Vehicle</li>
+                    <li>Vehicle manufactured in very low volume</li>
+                </ul>
+            </div>
+
+            <div class="refusal-list">
+                <p> Where a "Notification of Refusal" is issued, a further examination (a retest) will be carried
+                    out without further payment if: </p>
+                <p> - the vehicle is submitted for the examination at the place where it was previously examined, and</p>
+                <p> - the vehicle is submitted for examination before the end of the fifth day on which DVSA is accepting
+                    vehicles for inspection following the day of the original examination, and</p>
+                <p> - in the case of any vehicle category, the application is due to a failure to provide sufficient
+                    documentary evidence before the examination to demonstrate compliance, or</p>
+                <p> - in the case of an M1 or N1 category vehicle only, failure is due to one or more of the following
+                    items (subject to a maximum of six items)</p>
+            </div>
+
+            <ul class="item-list">
+                <li>Item 3           Fuel tanks/rear protective devices - fuel filler arrangements only;</li>
+                <li>Item 4           Rear registration plate space - all requirements;</li>
+                <li>Item 7           Audible warning - operation of audible warning device only;</li>
+                <li>Item 8           Indirect vision - all except field of view;</li>
+                <li>Item 9           Braking - warning lamps only;</li>
+                <li>Item 10         EMC - markings only;</li>
+                <li>Item 12         Interior fittings - no more than 3 separate examples of failure to comply;</li>
+                <li>Item 13         Anti-theft &amp; immobiliser - all requirements;</li>
+                <li>Item 16         Exterior projections - no more than 3 separate examples of failure to comply;</li>
+                <li>Item 17         Speedometer - illumination only;</li>
+                <li>Item 18         Plates - all requirements;</li>
+                <li>Item 20-30    Lighting - all except angle of visibility and position;</li>
+                <li>Item 31         Seat belts - child restraint warning label only;</li>
+                <li>Item 33         Controls - no more than 3 separate examples of failure to comply;</li>
+                <li>Item 34         Defrost/demist - all requirements;</li>
+                <li>Item 35         Wash/wipe - all requirements;</li>
+                <li>Item 36         Heating - all requirements;</li>
+                <li>Item 37         Wheel guards - all requirements;</li>
+                <li>Item 45         Safety glass - approval marking only;</li>
+                <li>Item 46         Tyres - approval marking, one example only;</li>
+
+            </ul>
+        </div>
+    </div>
+    <!-- second box -->
+    <div class="section-border">
+        <div class="section-title-border">
+            <h1>USE OF THE VEHICLE</h1>
+        </div>
+        <div class="section-text-wrapper">
+            <p id="no-margin-p">It is an offence to use a vehicle that requires type approval without an Individual Approval
+                Certificate confirming compliance with the type approval requirements, except for the purposes of:</p>
+            <ul class="vehicle-section-list">
+                <li> - submitting it, by previous arrangement, for an approval examination;</li>
+                <li> - bringing it away from such an examination;</li>
+                <li> - delivering it, by previous arrangement, to a place where relevant work is to be done on it following
+                    receipt of a refusal to issue an Individual Approval Certificate;</li>
+                <li> - bringing it away from a place where relevant work has been done on it.</li>
+            </ul>
+            <p>You may have been notified of defects in addition to those appertaining to the approval requirements.
+                Even in the above circumstances you may be committing an offence if you use the vehicle, and it does
+                not comply with the various regulations relating to its construction and use.</p>
+        </div>
+    </div>
+    <div class="section-border">
+        <div class="section-title-border">
+            <h1>YOUR RIGHT TO APPEAL</h1>
+        </div>
+        <div class="section-text-wrapper">
+            <p>If you do not agree with the Refusal to Issue an Individual Approval Certificate, you may appeal. If you
+                wish to appeal against all or any of the grounds for refusal you must complete form <u><b>IVA17</b></u> which is
+                available from the <b>GOV.UK</b> website, <a href="www.gov.uk/vehicleapproval">www.gov.uk/vehicleapproval</a>.
+                Send the form to <b><u>approvals@dvsa.gov.uk</u></b>. DVSA will advise you how to pay by credit/debit card
+                or prefunded account after you have applied. It costs the same as the original test. The appeal must be received
+                at the <b>DVSA, Ellipse, Padley Road, Swansea, SA1 8AN</b> within 14 days, beginning with the date of the issue of the
+                notification of refusal.</p>
+
+            <p>It is important that no modification/rectification work is carried out on the vehicle before the appeal
+                test as this may affect the outcome of the appeal.</p>
+        </div>
+    </div>
+</div>
+</body>
 </html>

--- a/src/main/resources/views/CommercialVehicles/IVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/IVA30.hbs
@@ -8,11 +8,11 @@
 </head>
 
 <body>
-<!-- FIRST PAGE HEADER -->
+
 <div class="first-page-header-left">
     <div class="header-serial-no">
         <div class="header-serial-no-title">
-            <span> <b>Serial Number: </b> <!-- Put Serial Number data here --> </span>
+            <span id="serial-no"> <b>Serial Number: </b> {{ivaData.serialNo}} </span>
         </div>
     </div>
     <div class="header-pagination">
@@ -24,7 +24,7 @@
     <img src="{{root}}/assets/images/dvsa_crest.png" alt="logo" width="110"/>
 </div>
 
-<!-- footer for all pages -->
+
 <div class="footer-left">
     <p> <b class="bold-title">IVA30VTA (DVSA0842) </b> </p>
 </div>
@@ -37,7 +37,7 @@
     <p><b>Version 1.0 Apr 2024</b></p>
 </div>
 
-<!-- first page -->
+
 <div class="separate-page">
     <div class="section-title-border" id ='cert-title-border'>
         <h1> INDIVIDUAL VEHICLE APPROVAL (IVA)</h1>
@@ -48,7 +48,7 @@
     <p id = "appointment-text"> AN APPOINTMENT FOR RE-EXAMINATION <b>CANNOT</b> BE MADE ON THE DAY ON WHICH THIS EXAMINATION WAS CARRIED OUT
         PLEASE CONTACT <b> (0300) 200 1188 </b> TO MAKE AN APPOINTMENT QUOTING YOUR TAS REFERENCE NUMBER </p>
 
-    <!--- Vehicle details section -->
+
     <table class="table">
         <thead>
         <th scope="row" colspan="2" class="section-title-border">
@@ -56,20 +56,20 @@
         </th>
         </thead>
         <tr class="table-row-cell">
-            <td class="table-row-cell"><b>Vehicle/Trailer NR No: </b> <!--Put data here --> </td>
-            <td class="table-row-cell"><b>Test Category: </b> <!--Put data here --> </td>
+            <td class="table-row-cell" id="veh-trl-no"><b>Vehicle/Trailer NR No: </b> {{ivaData.vehicleTrailerNrNo}} </td>
+            <td class="table-row-cell" id="test-category"><b>Test Category: </b> <span class="test-category-value">{{ivaData.testCategoryClass}}</span> ({{ivaData.testCategoryBasicNormal}}) </td>
         </tr>
         <tr class="table-row-cell">
-            <td class="table-row-cell"><b>Make/Model: </b> <!--Put data here --> </td>
-            <td class="table-row-cell"><b>VIN/Chassis No: </b> <!--Put data here --> </td>
+            <td class="table-row-cell" id="make-model"><b>Make/Model: </b> {{ivaData.make}}/{{ivaData.model}}</td>
+            <td class="table-row-cell" id="vin-chassis-no"><b>VIN/Chassis No: </b> {{ivaData.vin}} </td>
         </tr>
         <tr class="table-row-cell">
-            <td class="table-row-cell"> <b>Body Type: </b> <!--Put data here --> </td>
+            <td class="table-row-cell" id="body-type"> <b>Body Type: </b>{{ivaData.bodyType}} </td>
             <td class = "no-border-cell"></td>
         </tr>
     </table>
 
-    <!-- Required Standards Not Met Section -->
+
     <div class="section-border">
         <div class="section-title-border">
             <h1> DEFECT DETAILS </h1>
@@ -77,8 +77,24 @@
         <div class="section-title-border" id="defect-details-subtitle-border">
             <h1> Required Standard(s) Not Met: </h1>
         </div>
-        <div class="section-text-wrapper">
-            <!-- List incoming defects here -->
+        <div class="section-text-wrapper" id="required-standards">
+            {{#if ivaData.requiredStandards}}
+                <ul class="required-standard-list">
+                    {{#each ivaData.requiredStandards}}
+                        <li>
+                            <div>
+                                <p><span class="required-standard-section">{{this.sectionNumber}} - {{this.sectionDescription}}</span></p>
+                            </div>
+                            <div>
+                                <p><span> RS{{this.rsNumber}}: {{this.requiredStandard}} </span></p>
+                                {{#if this.additionalNotes}}
+                                    Additional Information: <span> {{this.additionalNotes}} </span>
+                                {{/if}}
+                            </div>
+                        </li>
+                    {{/each}}
+                </ul>
+            {{/if}}
         </div>
     </div>
 
@@ -86,31 +102,47 @@
         grounds that the vehicle fails to comply with the relevant requirements prescribed under The Road Vehicles
         (Approval) Regulations 2020 </p>
 
-    <!--- Signature Section --->
+
     <table class="table">
         <tr>
             <td></td>
-            <td class="table-row-cell"> <b>Reapplication required by: </b> <!--Put data here --> </td>
+            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{ivaData.reapplicationDate}} </td>
         </tr>
         <tr>
-            <td class="table-row-cell"> <b>Signed: </b> <!--Put data here --> </td>
-            <td class="table-row-cell"> <b>Date: </b>  <!--Put data here --> </td>
+            <td class="table-row-cell"> <b>Signed: </b> </td>
+            <td class="table-row-cell" id="date"> <b>Date: </b>  {{ivaData.date}} </td>
         </tr>
         <tr>
-            <td class="table-row-cell"> <b>Name: </b> <!--Put data here --> </td>
-            <td class="table-row-cell"> <b>Station: </b> <!--Put data here --> </td>
+            <td class="table-row-cell" id="tester-name"> <b>Name: </b> {{ivaData.testerName}} </td>
+            <td class="table-row-cell" id="station"> <b>Station: </b> {{ivaData.station}} </td>
         </tr>
         <tr>
             <td class="table-row-cell" colspan="2"> <p><b>The following additional defects may result in the vehicle not complying with the requirements
                 of The Road Vehicles (Construction and Use) Regulations 1986. (See notes overleaf) </b></p>
-                <p> N/A </p>
-                <!-- Put AdditionalDefects here -->
+                {{#if ivaData.additionalDefects}}
+                    <ul class="additional-defect-list" id="additional-defects">
+                        {{#each ivaData.additionalDefects}}
+                            <li>
+                                <div>
+                                    <span>
+                                        {{this.defectName}}
+                                    </span>
+                                </div>
+                                <div>
+                                    <span>
+                                        {{this.defectNotes}}
+                                    </span>
+                                </div>
+                            </li>
+                        {{/each}}
+                    </ul>
+                {{/if}}
             </td>
         </tr>
     </table>
 
 
-    <!-- Data Protection Section -->
+
     <div class="section-border">
         <div class="section-title-border">
             <h1> DATA PROTECTION STATEMENT 2019 </h1>
@@ -124,9 +156,9 @@
     </div>
 </div>
 
-<!-- back-page -->
+
 <div class="separate-page" id="back-page">
-    <!-- first box -->
+
     <div class="section-border">
         <div class="section-title-border">
             <h1>RE-EXAMINATION</h1>

--- a/src/test/java/htmlverification/framework/page_object/IvaPageObject.java
+++ b/src/test/java/htmlverification/framework/page_object/IvaPageObject.java
@@ -1,0 +1,58 @@
+package htmlverification.framework.page_object;
+
+import static htmlverification.framework.page_object.IvaPageSelector.*;
+
+public class IvaPageObject extends BasePageObject {
+    public IvaPageObject(String htmlContent) { super(htmlContent); }
+
+    public String getTextByElementId(String id) { return getElementById(id).text(); }
+    public String getTextByElementSelector(String selector) { return getElement(selector).text(); }
+
+    public String getSerialNumber() {
+        return getElementById(SERIAL_NO.getSelector()).text();
+    }
+
+    public String getVehicleTrailerNumber() {
+        return getElementById(VEH_TRL_NO.getSelector()).text();
+    }
+
+    public String getTestCategory() {
+        return getElementById(TEST_CATEGORY.getSelector()).text();
+    }
+
+    public String getMakeModel() {
+        return getElementById(MAKE_MODEL.getSelector()).text();
+    }
+
+    public String getVin() {
+        return getElementById(VIN.getSelector()).text();
+    }
+
+    public String getBodyType() {
+        return getElementById(BODY_TYPE.getSelector()).text();
+    }
+
+    public String getDate() {
+        return getElementById(DATE.getSelector()).text();
+    }
+
+    public String getReapplicationDate() {
+        return getElementById(RE_APP_DATE.getSelector()).text();
+    }
+
+    public String getTesterName() {
+        return getElementById(TESTER_NAME.getSelector()).text();
+    }
+
+    public String getStation() {
+        return getElementById(STATION.getSelector()).text();
+    }
+
+    public String getRequiredStandards() {
+        return getElementById(REQUIRED_STANDARDS.getSelector()).text();
+    }
+
+    public String getAdditionalDefects() {
+        return getElementById(ADDITIONAL_DEFECTS.getSelector()).text();
+    }
+}

--- a/src/test/java/htmlverification/framework/page_object/IvaPageSelector.java
+++ b/src/test/java/htmlverification/framework/page_object/IvaPageSelector.java
@@ -1,0 +1,26 @@
+package htmlverification.framework.page_object;
+
+public enum IvaPageSelector {
+    SERIAL_NO("serial-no"),
+    VEH_TRL_NO("veh-trl-no"),
+    TEST_CATEGORY("test-category"),
+    MAKE_MODEL("make-model"),
+    VIN("vin-chassis-no"),
+    BODY_TYPE("body-type"),
+    DATE("date"),
+    RE_APP_DATE("re-app-date"),
+    TESTER_NAME("tester-name"),
+    STATION("station"),
+    REQUIRED_STANDARDS("required-standards"),
+    ADDITIONAL_DEFECTS("additional-defects");
+
+    private final String selector;
+
+    IvaPageSelector(String selector) {
+        this.selector = selector;
+    }
+
+    public String getSelector() {
+        return selector;
+    }
+}

--- a/src/test/java/htmlverification/service/CvsCertificateTestDataProvider.java
+++ b/src/test/java/htmlverification/service/CvsCertificateTestDataProvider.java
@@ -590,6 +590,40 @@ public class CvsCertificateTestDataProvider {
         return vtg30;
     }
 
+    public static IVA30 getIVA30() {
+        IVA30 iva30 = new IVA30();
+        iva30.setDocumentName(CertificateTypes.IVA30.getCertificateType());
+        IvaFailCertificateData iva30Data = new IvaFailCertificateData();
+        iva30Data.setVin("T0000111134");
+        iva30Data.setSerialNo("012345");
+        iva30Data.setVehicleTrailerNrNo("ABC123");
+        iva30Data.setTestCategoryClass("M1");
+        iva30Data.setTestCategoryBasicNormal("Normal");
+        iva30Data.setMake("Make");
+        iva30Data.setModel("Model");
+        iva30Data.setBodyType("Body Type");
+        iva30Data.setDate("28/11/2023");
+        iva30Data.setTesterName("Tester One");
+        iva30Data.setReapplicationDate("27/05/2024");
+        iva30Data.setStation("Abshire-Kub");
+        iva30Data.setAdditionalDefects(new AdditionalDefect[]{new AdditionalDefect("DefectName", "DefectNotes")});
+        RequiredStandard mockRS = new RequiredStandard();
+        mockRS.setPrs(false);
+        mockRS.setRequiredStandard("Noise");
+        mockRS.setRefCalculation("1.1");
+        mockRS.setSectionNumber("1");
+        mockRS.setAdditionalInfo(false);
+        mockRS.setSectionDescription("description");
+        mockRS.setRsNumber(1);
+        mockRS.setInspectionTypes(new String[]{"Normal"});
+        mockRS.setAdditionalNotes("Some additional defect");
+        RequiredStandard[] requiredStandards = new RequiredStandard[]{mockRS};
+        iva30Data.setRequiredStandards(requiredStandards);
+        iva30.setIvaData(iva30Data);
+
+        return iva30;
+    }
+
     public static VTG30 getVtg30HavingInvalidXMLCharacter() {
         VTG30 document = getVtg30();
 

--- a/src/test/java/htmlverification/tests/IVA30Test.java
+++ b/src/test/java/htmlverification/tests/IVA30Test.java
@@ -1,0 +1,120 @@
+package htmlverification.tests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.jknack.handlebars.Handlebars;
+import htmlverification.framework.page_object.IvaPageObject;
+import htmlverification.service.CvsCertificateTestDataProvider;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.dvsa.model.cvs.IVA30;
+import uk.gov.dvsa.model.cvs.certificateData.AdditionalDefect;
+import uk.gov.dvsa.model.cvs.certificateData.RequiredStandard;
+import uk.gov.dvsa.service.HtmlGenerator;
+
+import static org.junit.Assert.assertEquals;
+
+public class IVA30Test {
+    protected HtmlGenerator htmlGenerator;
+    protected IVA30 testCertificate;
+    protected IvaPageObject ivaPageObject;
+
+    public IVA30Test() {
+        this.htmlGenerator = new HtmlGenerator(new Handlebars());
+    }
+
+    @Before
+    public void setup() throws JsonProcessingException {
+        testCertificate = CvsCertificateTestDataProvider.getIVA30();
+        String certHtmlIva30 = htmlGenerator.generate(testCertificate).get(0);
+        ivaPageObject = new IvaPageObject(certHtmlIva30);
+    }
+
+    @Test
+    public void verifySerialNumber() {
+        String serialNumber = ivaPageObject.getSerialNumber();
+        assertEquals("Serial Number: ".concat(testCertificate.getIvaData().getSerialNo()), serialNumber);
+    }
+
+    @Test
+    public void verifyVehicleTrailerNumber() {
+        String vehicleTrailerNumber = ivaPageObject.getVehicleTrailerNumber();
+        assertEquals("Vehicle/Trailer NR No: ".concat(testCertificate.getIvaData().getVehicleTrailerNrNo()), vehicleTrailerNumber);
+    }
+
+    @Test
+    public void verifyTestCategoryClass() {
+        String vehicleCategory = ivaPageObject.getTestCategory();
+        String testCatClass = testCertificate.getIvaData().getTestCategoryClass();
+        String testCatBasicNormal = testCertificate.getIvaData().getTestCategoryBasicNormal();
+        assertEquals("Test Category: ".concat(testCatClass + " (" + testCatBasicNormal + ")"), vehicleCategory);
+    }
+
+    @Test
+    public void verifyMakeModel() {
+        String makeModel = ivaPageObject.getMakeModel();
+        String htmlMake = testCertificate.getIvaData().getMake();
+        String htmlModel = testCertificate.getIvaData().getModel();
+        assertEquals("Make/Model: ".concat(htmlMake + "/" + htmlModel), makeModel);
+    }
+
+    @Test
+    public void verifyVin() {
+        String vin = ivaPageObject.getVin();
+        assertEquals("VIN/Chassis No: ".concat(testCertificate.getIvaData().getVin()), vin);
+    }
+
+    @Test
+    public void verifyBodyType() {
+        String bodyType = ivaPageObject.getBodyType();
+        assertEquals("Body Type: ".concat(testCertificate.getIvaData().getBodyType()), bodyType);
+    }
+
+    @Test
+    public void verifyDate() {
+        String date = ivaPageObject.getDate();
+        assertEquals("Date: ".concat(testCertificate.getIvaData().getDate()), date);
+    }
+
+    @Test
+    public void verifyReapplicationDate() {
+        String reapplicationDate = ivaPageObject.getReapplicationDate();
+        assertEquals("Reapplication required by: ".concat(testCertificate.getIvaData().getReapplicationDate()), reapplicationDate);
+    }
+
+    @Test
+    public void verifyTesterName() {
+        String testerName = ivaPageObject.getTesterName();
+        assertEquals("Name: ".concat(testCertificate.getIvaData().getTesterName()), testerName);
+    }
+
+    @Test
+    public void verifyStation() {
+        String station = ivaPageObject.getStation();
+        assertEquals("Station: ".concat(testCertificate.getIvaData().getStation()), station);
+    }
+
+    @Test
+    public void verifyRequiredStandards() {
+        String requiredStandards = ivaPageObject.getRequiredStandards();
+        RequiredStandard[] requiredStandardsArray = testCertificate.getIvaData().getRequiredStandards();
+
+        String sectionNo = requiredStandardsArray[0].getSectionNumber();
+        String description = requiredStandardsArray[0].getSectionDescription();
+        int rsNo = requiredStandardsArray[0].getRsNumber();
+        String rs = requiredStandardsArray[0].getRequiredStandard();
+        String addNotes = requiredStandardsArray[0].getAdditionalNotes();
+
+        assertEquals(sectionNo + " - " + description + " RS" + rsNo + ": " + rs + " Additional Information: " + addNotes, requiredStandards);
+    }
+
+    @Test
+    public void verifyAdditionalDefectsWhenNotApplicable() {
+        String additionalDefects = ivaPageObject.getAdditionalDefects();
+        AdditionalDefect[] additionalDefectsArray = testCertificate.getIvaData().getAdditionalDefects();
+
+        String defectName = additionalDefectsArray[0].getDefectName();
+        String defectNotes = additionalDefectsArray[0].getDefectNotes();
+
+        assertEquals(defectName + " " + defectNotes, additionalDefects);
+    }
+}

--- a/src/test/java/pdfverification/tests/IVA30Tests.java
+++ b/src/test/java/pdfverification/tests/IVA30Tests.java
@@ -1,0 +1,81 @@
+package pdfverification.tests;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.itextpdf.text.pdf.PdfReader;
+import htmlverification.service.CvsCertificateTestDataProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+import pdfverification.service.PDFParser;
+import uk.gov.dvsa.model.cvs.IVA30;
+import uk.gov.dvsa.service.HtmlGenerator;
+import uk.gov.dvsa.service.PDFGenerationService;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+public class IVA30Tests {
+    private static final String CERT_NAME = "INDIVIDUAL VEHICLE APPROVAL (IVA)";
+    private static final String FOOTER_DOC_NAME = "IVA30VTA (DVSA0842)";
+    private static final String FOOTER_VERSION_DATE = "Version 1.0 Apr 2024";
+    private PDFGenerationService pdfGenerationService;
+    private HtmlGenerator htmlGenerator;
+    private PDFParser pdfParser;
+    private IVA30 iva30;
+    private PdfReader pdfReader;
+    private byte[] pdfData;
+
+    public IVA30Tests() {
+        this.iva30 = CvsCertificateTestDataProvider.getIVA30();
+        this.htmlGenerator = new HtmlGenerator(new Handlebars());
+        this.pdfParser = new PDFParser();
+        this.pdfGenerationService = new PDFGenerationService(new ITextRenderer());
+    }
+
+    @Before
+    public void setup() throws IOException {
+        pdfData = pdfGenerationService.generate(htmlGenerator.generate(iva30));
+        pdfReader = pdfParser.readPdf(pdfData);
+    }
+
+    @Test
+    public void verifyTitleIsOnPage1() throws IOException {
+        assertTrue(pdfParser.getRawText(pdfReader, 1).contains(CERT_NAME));
+    }
+
+    @Test
+    public void verifyFormNameInFooterOnPage1() throws IOException {
+        assertTrue(pdfParser.getRawText(pdfReader, 1).contains(FOOTER_DOC_NAME));
+    }
+
+    @Test
+    public void verifyPageCounterOnPage1() throws IOException {
+        assertTrue(pdfParser.getRawText(pdfReader, 1).contains("1 of 2"));
+    }
+
+    @Test
+    public void verifyVersionNumberInFooterOnPage1() throws IOException {
+        assertTrue(pdfParser.getRawText(pdfReader, 1).contains(FOOTER_VERSION_DATE));
+    }
+
+    @Test
+    public void verifyPageCounterAtTopLeftOnPage1() throws IOException {
+        assertTrue(pdfParser.getRawText(pdfReader, 1).contains("Page 1 of 2"));
+    }
+
+    @Test
+    public void verifyFormNameInFooterOnPage2() throws IOException {
+        assertTrue(pdfParser.getRawText(pdfReader, 2).contains(FOOTER_DOC_NAME));
+    }
+
+    @Test
+    public void verifyPageCounterInFooterOnPage2() throws IOException {
+        assertTrue(pdfParser.getRawText(pdfReader, 2).contains("2 of 2"));
+    }
+
+    @Test
+    public void verifyVersionNumberInFooterOnPage2() throws IOException {
+        assertTrue(pdfParser.getRawText(pdfReader, 2).contains(FOOTER_VERSION_DATE));
+    }
+}


### PR DESCRIPTION
## Update Doc-Gen to Generate IVA30 Certificate

This code includes the changes made as part of the ticket [CB2-9976](https://dvsa.atlassian.net/browse/CB2-9976)

An IVA 30 document is produced for a failed IVA test with all required standards and additional defects displayed as per the test result.

Related issue: [CB2-10687](https://dvsa.atlassian.net/browse/CB2-10687)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
