### PR TITLE
feat(cb2-11479): Welsh Translations for missing text on Welsh Certs

### DIFF
--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/CvsMotFailCertificateDataWelsh.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/CvsMotFailCertificateDataWelsh.java
@@ -15,7 +15,7 @@ public class CvsMotFailCertificateDataWelsh extends CvsMotFailCertificateData {
     public static final String MINOR_DEFECTS_HEADER_WELSH = "Atgyweiriwch cyn gynted â phosibl (ddiffygion bach)";
     public static final String DANGEROUS_DEFECTS_HEADER_WELSH = "Peidiwch â gyrru nes ei fod wedi cael ei atgyweirio (diffygion peryglus)";
     public static final String MAJOR_DEFECT_HEADER_WELSH = "Atgyweirio ar unwaith (diffygion mawr)";
-    public static final String PRS_DEFECTS_HEADER_WELSH = "Defects rectified at time of test"; // TODO - Welsh translation
+    public static final String PRS_DEFECTS_HEADER_WELSH = "Diffygion wedi'u cywiro ar adeg y prawf"; // TODO - Welsh translation
     public static final String TESTING_ORGANISATION_WELSH = "ASIANTAETH SAFONAU GYRWYR A CHERBYDAU";
 
     @JsonProperty("AdvisoryDefectsWelsh")

--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/CvsMotFailCertificateDataWelsh.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/CvsMotFailCertificateDataWelsh.java
@@ -15,7 +15,7 @@ public class CvsMotFailCertificateDataWelsh extends CvsMotFailCertificateData {
     public static final String MINOR_DEFECTS_HEADER_WELSH = "Atgyweiriwch cyn gynted â phosibl (ddiffygion bach)";
     public static final String DANGEROUS_DEFECTS_HEADER_WELSH = "Peidiwch â gyrru nes ei fod wedi cael ei atgyweirio (diffygion peryglus)";
     public static final String MAJOR_DEFECT_HEADER_WELSH = "Atgyweirio ar unwaith (diffygion mawr)";
-    public static final String PRS_DEFECTS_HEADER_WELSH = "Diffygion wedi'u cywiro ar adeg y prawf"; // TODO - Welsh translation
+    public static final String PRS_DEFECTS_HEADER_WELSH = "Diffygion wedi'u cywiro ar adeg y prawf";
     public static final String TESTING_ORGANISATION_WELSH = "ASIANTAETH SAFONAU GYRWYR A CHERBYDAU";
 
     @JsonProperty("AdvisoryDefectsWelsh")

--- a/src/main/resources/views/CommercialVehicles/VTG30Welsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG30Welsh.hbs
@@ -344,7 +344,7 @@
                 {{#if reissue}}
                 <div class="util-avoid-page-break-inside" id="reissueInfo">
                     <p class="test-information__message">
-                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                        Tystysgrif amnewid a gyhoeddwyd gan {{reissue.issuer}} ar {{reissue.date}}
                     </p>
                 </div>
                 {{/if}}

--- a/src/main/resources/views/CommercialVehicles/VTG30Welsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG30Welsh.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    <p class="heading-info--no-margin">Tystysgrif</p>
                     {{/if}}
                     Gwrthod tystysgrif prawf MOT
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/VTG30Welsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/VTG30Welsh.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">Tystysgrif</p>
+                    <p class="heading-info--no-margin">Amnewid</p>
                     {{/if}}
                     Gwrthod tystysgrif prawf MOT
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/fail.hbs
+++ b/src/main/resources/views/CommercialVehicles/fail.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">Tystysgrif</p>
+                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
                     {{/if}}
                     Refusal of MOT test certificate
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/fail.hbs
+++ b/src/main/resources/views/CommercialVehicles/fail.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    <p class="heading-info--no-margin">Tystysgrif</p>
                     {{/if}}
                     Refusal of MOT test certificate
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/failWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/failWelsh.hbs
@@ -321,7 +321,7 @@
                 {{#if reissue}}
                 <div class="util-avoid-page-break-inside" id="reissueInfo">
                     <p class="test-information__message">
-                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                        Tystysgrif amnewid a gyhoeddwyd gan {{reissue.issuer}} ar {{reissue.date}}
                     </p>
                 </div>
                 {{/if}}

--- a/src/main/resources/views/CommercialVehicles/failWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/failWelsh.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    <p class="heading-info--no-margin">Tystysgrif</p>
                     {{/if}}
                     Gwrthod tystysgrif prawf MOT
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/failWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/failWelsh.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">Tystysgrif</p>
+                    <p class="heading-info--no-margin">Amnewid</p>
                     {{/if}}
                     Gwrthod tystysgrif prawf MOT
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/passNoSeatbeltFieldsWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/passNoSeatbeltFieldsWelsh.hbs
@@ -401,7 +401,7 @@
                 {{#if reissue}}
                 <div class="util-avoid-page-break-inside" id="reissueInfo">
                     <p class="test-information__message">
-                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                        Tystysgrif amnewid a gyhoeddwyd gan {{reissue.issuer}} ar {{reissue.date}}
                     </p>
                 </div>
                 {{/if}}

--- a/src/main/resources/views/CommercialVehicles/passNoSeatbeltFieldsWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/passNoSeatbeltFieldsWelsh.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    <p class="heading-info--no-margin">Tystysgrif</p>
                     {{/if}}
                     Tystysgrif prawf MOT ({{testType}})
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/passNoSeatbeltFieldsWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/passNoSeatbeltFieldsWelsh.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">Tystysgrif</p>
+                    <p class="heading-info--no-margin">Amnewid</p>
                     {{/if}}
                     Tystysgrif prawf MOT ({{testType}})
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/passWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/passWelsh.hbs
@@ -392,7 +392,7 @@
                 {{#if reissue}}
                 <div class="util-avoid-page-break-inside" id="reissueInfo">
                     <p class="test-information__message">
-                        {{reissue.reason}} certificate issued by {{reissue.issuer}} on {{reissue.date}}
+                        Tystysgrif amnewid a gyhoeddwyd gan {{reissue.issuer}} ar {{reissue.date}}
                     </p>
                 </div>
                 {{/if}}

--- a/src/main/resources/views/CommercialVehicles/passWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/passWelsh.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">{{reissue.reason}}</p>
+                    <p class="heading-info--no-margin">Tystysgrif</p>
                     {{/if}}
                     Tystysgrif prawf MOT ({{testType}})
                 </h1>

--- a/src/main/resources/views/CommercialVehicles/passWelsh.hbs
+++ b/src/main/resources/views/CommercialVehicles/passWelsh.hbs
@@ -84,7 +84,7 @@
             <div class="header__left">
                 <h1 class="header__title">
                     {{#if reissue}}
-                    <p class="heading-info--no-margin">Tystysgrif</p>
+                    <p class="heading-info--no-margin">Amnewid</p>
                     {{/if}}
                     Tystysgrif prawf MOT ({{testType}})
                 </h1>


### PR DESCRIPTION
… certificates

## Description

Added the translated text for welsh certificates for the remaining hardcoded English text still present on the forms

Related issue: [CB2-11479](https://dvsa.atlassian.net/browse/CB2-11479)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
