### PR TITLE
feat(cb2-12533): Update to reapplication date field and text on IVA30/MSVA30

### DIFF
--- a/src/main/resources/views/CommercialVehicles/IVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/IVA30.hbs
@@ -34,7 +34,7 @@
     <span class="footer-total-page-count"></span>
 </div>
 <div class = "footer-right">
-    <p><b>Version 1.0 Apr 2024</b></p>
+    <p><b>Version 1.1 June 2024</b></p>
 </div>
 
 
@@ -112,7 +112,7 @@
                         <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
                 </div>
             </td>
-            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{ivaData.reapplicationDate}} </td>
+            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> </td>
         </tr>
         <tr>
             <td class="table-row-cell" id="date"> <b>Date: </b>  {{ivaData.date}} </td>
@@ -171,7 +171,7 @@
         <div class="section-text-wrapper">
             <p> This notification indicates the items of non-compliance being the reason(s)
                 why an Individual Approval Certificate (IAC) has not been issued. An application
-                for re-examination can be made up to 6 calendar months following the issue date
+                for re-examination must be made no later than 6 months following the issue date
                 of the first "Notification of Refusal" in respect of the original application.
                 In any other case, a new application and a full fee must be submitted.</p>
             <p> When modification/rectification has been completed, or additional evidence of

--- a/src/main/resources/views/CommercialVehicles/MSVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/MSVA30.hbs
@@ -107,7 +107,7 @@
                         <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
                 </div>
             </td>
-            <td class="table-row-cell" id="re-app-date"> <b>Retest required by: </b> </td>
+            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> </td>
         </tr>
         <tr>
             <td class="table-row-cell" id="date"> <b>Date: </b> {{msvaData.date}} </td>

--- a/src/main/resources/views/CommercialVehicles/MSVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/MSVA30.hbs
@@ -34,7 +34,7 @@
     <span class="footer-total-page-count"></span>
 </div>
 <div class = "footer-right">
-    <p><b>Version 1.0 May 2024</b></p>
+    <p><b>Version 1.1 June 2024</b></p>
 </div>
 
 
@@ -107,7 +107,7 @@
                         <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
                 </div>
             </td>
-            <td class="table-row-cell" id="re-app-date"> <b>Retest required by: </b> {{msvaData.retestDate}} </td>
+            <td class="table-row-cell" id="re-app-date"> <b>Retest required by: </b> </td>
         </tr>
         <tr>
             <td class="table-row-cell" id="date"> <b>Date: </b> {{msvaData.date}} </td>
@@ -166,7 +166,7 @@
         <div class="section-text-wrapper">
             <p> This notification indicates the items of non-compliance being the reason(s)
                 why a Minister's Approval Certificate (MAC) has not been issued. An application
-                for re-examination can be made up to 6 calendar months following the issue date
+                for re-examination must be made no later than 6 months following the issue date
                 of the first "Notification of Refusal" in respect of the original application.
                 In any other case, a new application and a full fee must be submitted.</p>
             <p> When modification/rectification, etc. has been completed an application for a re-examination (verbally or in writing)

--- a/src/test/java/htmlverification/tests/IVA30Test.java
+++ b/src/test/java/htmlverification/tests/IVA30Test.java
@@ -86,7 +86,7 @@ public class IVA30Test {
     @Test
     public void verifyReapplicationDate() {
         String reapplicationDate = ivaPageObject.getReapplicationDate();
-        assertEquals("Reapplication required by: ".concat(testCertificate.getIvaData().getReapplicationDate()), reapplicationDate);
+        assertEquals("Reapplication required by:", reapplicationDate);
     }
 
     @Test

--- a/src/test/java/htmlverification/tests/MSVA30Test.java
+++ b/src/test/java/htmlverification/tests/MSVA30Test.java
@@ -79,7 +79,7 @@ public class MSVA30Test {
     @Test
     public void verifyRetestDate() {
         String retestDate = msvaPageObject.getRetestDate();
-        assertEquals("Retest required by:", retestDate);
+        assertEquals("Reapplication required by:", retestDate);
     }
 
     @Test

--- a/src/test/java/htmlverification/tests/MSVA30Test.java
+++ b/src/test/java/htmlverification/tests/MSVA30Test.java
@@ -79,7 +79,7 @@ public class MSVA30Test {
     @Test
     public void verifyRetestDate() {
         String retestDate = msvaPageObject.getRetestDate();
-        assertEquals("Retest required by: ".concat(testCertificate.getMsvaData().getRetestDate()), retestDate);
+        assertEquals("Retest required by:", retestDate);
     }
 
     @Test

--- a/src/test/java/pdfverification/tests/IVA30Tests.java
+++ b/src/test/java/pdfverification/tests/IVA30Tests.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 public class IVA30Tests {
     private static final String CERT_NAME = "INDIVIDUAL VEHICLE APPROVAL (IVA)";
     private static final String FOOTER_DOC_NAME = "IVA30VTA (DVSA0842)";
-    private static final String FOOTER_VERSION_DATE = "Version 1.0 Apr 2024";
+    private static final String FOOTER_VERSION_DATE = "Version 1.1 June 2024";
     private PDFGenerationService pdfGenerationService;
     private HtmlGenerator htmlGenerator;
     private PDFParser pdfParser;

--- a/src/test/java/pdfverification/tests/MSVA30Tests.java
+++ b/src/test/java/pdfverification/tests/MSVA30Tests.java
@@ -21,7 +21,7 @@ public class MSVA30Tests {
 
     private final String FOOTER_DOC_NAME = "MSVA30VTA (DVSA0848)";
 
-    private final String FOOTER_VERSION_DATE = "Version 1.0 May 2024";
+    private final String FOOTER_VERSION_DATE = "Version 1.1 June 2024";
 
     private PDFGenerationService pdfGenerationService;
     private HtmlGenerator htmlGenerator;


### PR DESCRIPTION
## Made the following changes as per policy request 10/06/2024

- Removed Reapplication Date value from IVA30
- Removed Retest Date value from MSVA30
- Updated wording around reapplication date on IVA30
- Updated wording around retest date on MSVA30
- Updated tests

There will be subsequent tickets created at a later date to add the value back into the templates, at such a time the correct logic has been provided. In the meantime is has been requested the value is simply removed from the certificates generated.

Related issue: [CB2-12533](https://dvsa.atlassian.net/browse/CB2-12533)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [X] Did you make sure to update any documentation relating to this change?
