### PR TITLE
feat(CB2-12602): Display re-application date from test-results on IVA30 and MSVA30

### DIFF
--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/IvaFailCertificateData.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/IvaFailCertificateData.java
@@ -23,8 +23,6 @@ public class IvaFailCertificateData {
     private String bodyType;
     @JsonProperty("date")
     private String date;
-    @JsonProperty("reapplicationDate")
-    private String reapplicationDate;
     @JsonProperty("station")
     private String station;
     @JsonProperty("testerName")
@@ -33,6 +31,8 @@ public class IvaFailCertificateData {
     private AdditionalDefect[] additionalDefects;
     @JsonProperty("requiredStandards")
     private RequiredStandard[] requiredStandards;
+    @JsonProperty("reapplicationDate")
+    private String reapplicationDate;
 
     public String getSerialNo() {
         return serialNo;
@@ -106,14 +106,6 @@ public class IvaFailCertificateData {
         this.date = date;
     }
 
-    public String getReapplicationDate() {
-        return reapplicationDate;
-    }
-
-    public void setReapplicationDate(String reapplicationDate) {
-        this.reapplicationDate = reapplicationDate;
-    }
-
     public String getStation() {
         return station;
     }
@@ -146,5 +138,11 @@ public class IvaFailCertificateData {
         this.requiredStandards = requiredStandards;
     }
 
+    public String getReapplicationDate() {
+        return reapplicationDate;
+    }
 
+    public void setReapplicationDate(String reapplicationDate) {
+        this.reapplicationDate = reapplicationDate;
+    }
 }

--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/IvaFailCertificateData.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/IvaFailCertificateData.java
@@ -145,4 +145,6 @@ public class IvaFailCertificateData {
     public void setRequiredStandards(RequiredStandard[] requiredStandards) {
         this.requiredStandards = requiredStandards;
     }
+
+
 }

--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/IvaFailCertificateData.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/IvaFailCertificateData.java
@@ -23,6 +23,8 @@ public class IvaFailCertificateData {
     private String bodyType;
     @JsonProperty("date")
     private String date;
+    @JsonProperty("reapplicationDate")
+    private String reapplicationDate;
     @JsonProperty("station")
     private String station;
     @JsonProperty("testerName")
@@ -31,8 +33,6 @@ public class IvaFailCertificateData {
     private AdditionalDefect[] additionalDefects;
     @JsonProperty("requiredStandards")
     private RequiredStandard[] requiredStandards;
-    @JsonProperty("reapplicationDate")
-    private String reapplicationDate;
 
     public String getSerialNo() {
         return serialNo;
@@ -106,6 +106,14 @@ public class IvaFailCertificateData {
         this.date = date;
     }
 
+    public String getReapplicationDate() {
+        return reapplicationDate;
+    }
+
+    public void setReapplicationDate(String reapplicationDate) {
+        this.reapplicationDate = reapplicationDate;
+    }
+
     public String getStation() {
         return station;
     }
@@ -136,13 +144,5 @@ public class IvaFailCertificateData {
 
     public void setRequiredStandards(RequiredStandard[] requiredStandards) {
         this.requiredStandards = requiredStandards;
-    }
-
-    public String getReapplicationDate() {
-        return reapplicationDate;
-    }
-
-    public void setReapplicationDate(String reapplicationDate) {
-        this.reapplicationDate = reapplicationDate;
     }
 }

--- a/src/main/java/uk/gov/dvsa/model/cvs/certificateData/MsvaFailCertificateData.java
+++ b/src/main/java/uk/gov/dvsa/model/cvs/certificateData/MsvaFailCertificateData.java
@@ -19,8 +19,8 @@ public class MsvaFailCertificateData {
     private String model;
     @JsonProperty("date")
     private String date;
-    @JsonProperty("retestDate")
-    private String retestDate;
+    @JsonProperty("reapplicationDate")
+    private String reapplicationDate;
     @JsonProperty("station")
     private String station;
     @JsonProperty("testerName")
@@ -86,12 +86,12 @@ public class MsvaFailCertificateData {
         this.date = date;
     }
 
-    public String getRetestDate() {
-        return retestDate;
+    public String getReapplicationDate() {
+        return reapplicationDate;
     }
 
-    public void setRetestDate(String retestDate) {
-        this.retestDate = retestDate;
+    public void setReapplicationDate(String reapplicationDate) {
+        this.reapplicationDate = reapplicationDate;
     }
 
     public String getStation() {

--- a/src/main/resources/views/CommercialVehicles/IVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/IVA30.hbs
@@ -112,7 +112,7 @@
                         <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
                 </div>
             </td>
-            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{ivadData.reapplicationDate}} </td>
+            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{ivaData.reapplicationDate}} </td>
         </tr>
         <tr>
             <td class="table-row-cell" id="date"> <b>Date: </b>  {{ivaData.date}} </td>

--- a/src/main/resources/views/CommercialVehicles/IVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/IVA30.hbs
@@ -34,7 +34,7 @@
     <span class="footer-total-page-count"></span>
 </div>
 <div class = "footer-right">
-    <p><b>Version 1.1 June 2024</b></p>
+    <p><b>Version 1.2 July 2024</b></p>
 </div>
 
 

--- a/src/main/resources/views/CommercialVehicles/IVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/IVA30.hbs
@@ -112,7 +112,7 @@
                         <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
                 </div>
             </td>
-            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> </td>
+            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{ivadData.reapplicationDate}} </td>
         </tr>
         <tr>
             <td class="table-row-cell" id="date"> <b>Date: </b>  {{ivaData.date}} </td>

--- a/src/main/resources/views/CommercialVehicles/MSVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/MSVA30.hbs
@@ -34,7 +34,7 @@
     <span class="footer-total-page-count"></span>
 </div>
 <div class = "footer-right">
-    <p><b>Version 1.1 June 2024</b></p>
+    <p><b>Version 1.2 July 2024</b></p>
 </div>
 
 

--- a/src/main/resources/views/CommercialVehicles/MSVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/MSVA30.hbs
@@ -107,7 +107,7 @@
                         <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
                 </div>
             </td>
-            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> </td>
+            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{msvaData.reapplicationDate}} </td>
         </tr>
         <tr>
             <td class="table-row-cell" id="date"> <b>Date: </b> {{msvaData.date}} </td>

--- a/src/test/java/htmlverification/framework/page_object/MsvaPageObject.java
+++ b/src/test/java/htmlverification/framework/page_object/MsvaPageObject.java
@@ -37,7 +37,7 @@ public class MsvaPageObject extends BasePageObject {
         return getElementById(DATE.getSelector()).text();
     }
 
-    public String getRetestDate() {
+    public String getReapplicationDate() {
         return getElementById(RE_APP_DATE.getSelector()).text();
     }
 

--- a/src/test/java/htmlverification/service/CvsCertificateTestDataProvider.java
+++ b/src/test/java/htmlverification/service/CvsCertificateTestDataProvider.java
@@ -1074,7 +1074,7 @@ public class CvsCertificateTestDataProvider {
         msva30Data.setModel("Model");
         msva30Data.setDate("28/11/2023");
         msva30Data.setTesterName("Tester One");
-        msva30Data.setRetestDate("27/05/2024");
+        msva30Data.setReapplicationDate("27/05/2024");
         msva30Data.setStation("Abshire-Kub");
         msva30Data.setAdditionalDefects(new AdditionalDefect[]{new AdditionalDefect("DefectName", "DefectNotes")});
         RequiredStandard mockRS = new RequiredStandard();

--- a/src/test/java/htmlverification/tests/IVA30Test.java
+++ b/src/test/java/htmlverification/tests/IVA30Test.java
@@ -89,7 +89,7 @@ public class IVA30Test {
     @Test
     public void verifyReapplicationDate() {
         String reapplicationDate = ivaPageObject.getReapplicationDate();
-        assertEquals("Reapplication required by:", reapplicationDate);
+        assertEquals("Reapplication required by: 27/05/2024", reapplicationDate);
     }
 
     @Test

--- a/src/test/java/htmlverification/tests/IVA30Test.java
+++ b/src/test/java/htmlverification/tests/IVA30Test.java
@@ -11,6 +11,9 @@ import uk.gov.dvsa.model.cvs.certificateData.AdditionalDefect;
 import uk.gov.dvsa.model.cvs.certificateData.RequiredStandard;
 import uk.gov.dvsa.service.HtmlGenerator;
 
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
 import static org.junit.Assert.assertEquals;
 
 public class IVA30Test {

--- a/src/test/java/htmlverification/tests/IVA30Test.java
+++ b/src/test/java/htmlverification/tests/IVA30Test.java
@@ -11,9 +11,6 @@ import uk.gov.dvsa.model.cvs.certificateData.AdditionalDefect;
 import uk.gov.dvsa.model.cvs.certificateData.RequiredStandard;
 import uk.gov.dvsa.service.HtmlGenerator;
 
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-
 import static org.junit.Assert.assertEquals;
 
 public class IVA30Test {

--- a/src/test/java/htmlverification/tests/MSVA30Test.java
+++ b/src/test/java/htmlverification/tests/MSVA30Test.java
@@ -77,9 +77,9 @@ public class MSVA30Test {
     }
 
     @Test
-    public void verifyRetestDate() {
-        String retestDate = msvaPageObject.getRetestDate();
-        assertEquals("Reapplication required by:", retestDate);
+    public void verifyReapplicationDate() {
+        String retestDate = msvaPageObject.getReapplicationDate();
+        assertEquals("Reapplication required by: 27/05/2024", retestDate);
     }
 
     @Test

--- a/src/test/java/pdfverification/tests/IVA30Tests.java
+++ b/src/test/java/pdfverification/tests/IVA30Tests.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 public class IVA30Tests {
     private static final String CERT_NAME = "INDIVIDUAL VEHICLE APPROVAL (IVA)";
     private static final String FOOTER_DOC_NAME = "IVA30VTA (DVSA0842)";
-    private static final String FOOTER_VERSION_DATE = "Version 1.1 June 2024";
+    private static final String FOOTER_VERSION_DATE = "Version 1.2 July 2024";
     private PDFGenerationService pdfGenerationService;
     private HtmlGenerator htmlGenerator;
     private PDFParser pdfParser;

--- a/src/test/java/pdfverification/tests/IVA30Tests.java
+++ b/src/test/java/pdfverification/tests/IVA30Tests.java
@@ -13,6 +13,7 @@ import uk.gov.dvsa.service.PDFGenerationService;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class IVA30Tests {

--- a/src/test/java/pdfverification/tests/IVA30Tests.java
+++ b/src/test/java/pdfverification/tests/IVA30Tests.java
@@ -13,7 +13,6 @@ import uk.gov.dvsa.service.PDFGenerationService;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class IVA30Tests {

--- a/src/test/java/pdfverification/tests/IVA30Tests.java
+++ b/src/test/java/pdfverification/tests/IVA30Tests.java
@@ -13,7 +13,6 @@ import uk.gov.dvsa.service.PDFGenerationService;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class IVA30Tests {
@@ -38,9 +37,6 @@ public class IVA30Tests {
     public void setup() throws IOException {
         pdfData = pdfGenerationService.generate(htmlGenerator.generate(iva30));
         pdfReader = pdfParser.readPdf(pdfData);
-        FileOutputStream fileOutputStream  = new FileOutputStream("dan.pdf");
-        fileOutputStream.write(pdfData);
-        fileOutputStream.close();
     }
 
     @Test

--- a/src/test/java/pdfverification/tests/IVA30Tests.java
+++ b/src/test/java/pdfverification/tests/IVA30Tests.java
@@ -13,6 +13,7 @@ import uk.gov.dvsa.service.PDFGenerationService;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class IVA30Tests {
@@ -37,6 +38,9 @@ public class IVA30Tests {
     public void setup() throws IOException {
         pdfData = pdfGenerationService.generate(htmlGenerator.generate(iva30));
         pdfReader = pdfParser.readPdf(pdfData);
+        FileOutputStream fileOutputStream  = new FileOutputStream("dan.pdf");
+        fileOutputStream.write(pdfData);
+        fileOutputStream.close();
     }
 
     @Test

--- a/src/test/java/pdfverification/tests/MSVA30Tests.java
+++ b/src/test/java/pdfverification/tests/MSVA30Tests.java
@@ -21,7 +21,7 @@ public class MSVA30Tests {
 
     private final String FOOTER_DOC_NAME = "MSVA30VTA (DVSA0848)";
 
-    private final String FOOTER_VERSION_DATE = "Version 1.1 June 2024";
+    private final String FOOTER_VERSION_DATE = "Version 1.2 July 2024";
 
     private PDFGenerationService pdfGenerationService;
     private HtmlGenerator htmlGenerator;


### PR DESCRIPTION
## Display re-application date from test-results on IVA30 and MSVA30

Added re-application date to the IVA fail certificate data and into IVA and MSVA certificate so that I can be displayed.
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-12602)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
