### PR TITLE
feat(CB2-12597): Page Break on IVA30 and MSVA30 when list of defects spans >1 page

### DIFF
--- a/src/main/resources/assets/stylesheets/iva-msva-30.hbs
+++ b/src/main/resources/assets/stylesheets/iva-msva-30.hbs
@@ -141,14 +141,6 @@ text-align: center-left;
 width:100%;
 }
 
-.separate-page{
-page-break-after: always;
-}
-
-#back-page{
-page-break-after: avoid;
-}
-
 .section-border {
 border-style: solid;
 border-color: black;
@@ -165,6 +157,10 @@ text-align: center;
 margin-top: -1px;
 margin-left: -1px;
 width: 100.3%;
+}
+
+#defect-section {
+page-break-inside: auto;
 }
 
 #cert-subtitle{
@@ -226,6 +222,11 @@ text-transform:uppercase;
 
 .required-standard-list {
 list-style-type: none;
+}
+
+.required-standard-list-item {
+page-break-inside: avoid;
+margin-bottom: 20px;
 }
 
 .required-standard-section {

--- a/src/main/resources/views/CommercialVehicles/IVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/IVA30.hbs
@@ -38,7 +38,6 @@
 </div>
 
 
-<div class="separate-page">
     <div class="section-title-border" id ='cert-title-border'>
         <h1> INDIVIDUAL VEHICLE APPROVAL (IVA)</h1>
         <h1> NOTIFICATION OF REFUSAL TO ISSUE AN INDIVIDUAL APPROVAL CERTIFICATE </h1>
@@ -70,7 +69,7 @@
     </table>
 
 
-    <div class="section-border">
+    <div class="section-border" id = "defect-section">
         <div class="section-title-border">
             <h1> DEFECT DETAILS </h1>
         </div>
@@ -81,12 +80,12 @@
             {{#if ivaData.requiredStandards}}
                 <ul class="required-standard-list">
                     {{#each ivaData.requiredStandards}}
-                        <li>
+                        <li class= "required-standard-list-item">
                             <div>
                                 <p><span class="required-standard-section">{{this.sectionNumber}} - {{this.sectionDescription}}</span></p>
                             </div>
                             <div>
-                                <p><span> RS{{this.rsNumber}}: {{this.requiredStandard}} </span></p>
+                                <p><span> RS{{this.rsNumber}}: {{this.requiredStandard}} {{#if this.prs}} (PRS) {{/if}}</span></p>
                                 {{#if this.additionalNotes}}
                                     Additional Information: <span> {{this.additionalNotes}} </span>
                                 {{/if}}
@@ -97,55 +96,55 @@
             {{/if}}
         </div>
     </div>
+    <div class = "signature-section">
+        <p> I hereby refuse an Individual Approval Certificate in respect of the above described vehicle on the
+            grounds that the vehicle fails to comply with the relevant requirements prescribed under The Road Vehicles
+            (Approval) Regulations 2020 </p>
 
-    <p> I hereby refuse an Individual Approval Certificate in respect of the above described vehicle on the
-        grounds that the vehicle fails to comply with the relevant requirements prescribed under The Road Vehicles
-        (Approval) Regulations 2020 </p>
 
-
-    <table class="table">
-        <tr>
-            <td rowspan="2" class="table-row-cell">
-                <div>
-                    <b class="signature-label">Signed: </b>
-                    <div class="signature-image__wrapper">
-                        <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
-                </div>
-            </td>
-            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{ivaData.reapplicationDate}} </td>
-        </tr>
-        <tr>
-            <td class="table-row-cell" id="date"> <b>Date: </b>  {{ivaData.date}} </td>
-        </tr>
-        <tr>
-            <td class="table-row-cell" id="tester-name"> <b>Name: </b> {{ivaData.testerName}} </td>
-            <td class="table-row-cell" id="station"> <b>Station: </b> {{ivaData.station}} </td>
-        </tr>
-        <tr>
-            <td class="table-row-cell" colspan="2"> <p><b>The following additional defects may result in the vehicle not complying with the requirements
-                of The Road Vehicles (Construction and Use) Regulations 1986. (See notes overleaf) </b></p>
-                {{#if ivaData.additionalDefects}}
-                    <ul class="additional-defect-list" id="additional-defects">
-                        {{#each ivaData.additionalDefects}}
-                            <li>
-                                <div>
-                                    <span>
-                                        {{this.defectName}}
-                                    </span>
-                                </div>
-                                <div>
-                                    <span>
-                                        {{this.defectNotes}}
-                                    </span>
-                                </div>
-                            </li>
-                        {{/each}}
-                    </ul>
-                {{/if}}
-            </td>
-        </tr>
-    </table>
-
+        <table class="table">
+            <tr>
+                <td rowspan="2" class="table-row-cell">
+                    <div>
+                        <b class="signature-label">Signed: </b>
+                        <div class="signature-image__wrapper">
+                            <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
+                    </div>
+                </td>
+                <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> </td>
+            </tr>
+            <tr>
+                <td class="table-row-cell" id="date"> <b>Date: </b>  {{ivaData.date}} </td>
+            </tr>
+            <tr>
+                <td class="table-row-cell" id="tester-name"> <b>Name: </b> {{ivaData.testerName}} </td>
+                <td class="table-row-cell" id="station"> <b>Station: </b> {{ivaData.station}} </td>
+            </tr>
+            <tr>
+                <td class="table-row-cell" colspan="2"> <p><b>The following additional defects may result in the vehicle not complying with the requirements
+                    of The Road Vehicles (Construction and Use) Regulations 1986. (See notes overleaf) </b></p>
+                    {{#if ivaData.additionalDefects}}
+                        <ul class="additional-defect-list" id="additional-defects">
+                            {{#each ivaData.additionalDefects}}
+                                <li>
+                                    <div>
+                                        <span>
+                                            {{this.defectName}}
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span>
+                                            {{this.defectNotes}}
+                                        </span>
+                                    </div>
+                                </li>
+                            {{/each}}
+                        </ul>
+                    {{/if}}
+                </td>
+            </tr>
+        </table>
+    </div>
 
 
     <div class="section-border">
@@ -159,10 +158,6 @@
                 investigation or to prevent fraud. Find out more at <a href="www.gov.uk/dvsa/privacy">www.gov.uk/dvsa/privacy</a></p>
         </div>
     </div>
-</div>
-
-
-<div class="separate-page" id="back-page">
 
     <div class="section-border">
         <div class="section-title-border">
@@ -271,6 +266,5 @@
                 test as this may affect the outcome of the appeal.</p>
         </div>
     </div>
-</div>
 </body>
 </html>

--- a/src/main/resources/views/CommercialVehicles/IVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/IVA30.hbs
@@ -111,7 +111,7 @@
                             <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
                     </div>
                 </td>
-                <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> </td>
+                <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{ivaData.reapplicationDate}} </td>
             </tr>
             <tr>
                 <td class="table-row-cell" id="date"> <b>Date: </b>  {{ivaData.date}} </td>

--- a/src/main/resources/views/CommercialVehicles/MSVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/MSVA30.hbs
@@ -38,7 +38,6 @@
 </div>
 
 
-<div class="separate-page">
     <div class="section-title-border" id ='cert-title-border'>
         <h1> MOTORCYCLE SINGLE VEHICLE APPROVAL (MSVA)</h1>
         <h1> NOTIFICATION OF REFUSAL TO ISSUE A MINISTERS APPROVAL CERTIFICATE </h1>
@@ -65,7 +64,7 @@
     </table>
 
 
-    <div class="section-border">
+    <div class="section-border" id = "defect-section">
         <div class="section-title-border">
             <h1> DEFECT DETAILS </h1>
         </div>
@@ -76,12 +75,12 @@
             {{#if msvaData.requiredStandards}}
                 <ul class="required-standard-list">
                     {{#each msvaData.requiredStandards}}
-                        <li>
+                        <li class= "required-standard-list-item">
                             <div>
                                 <p><span class="required-standard-section">{{this.sectionNumber}} - {{this.sectionDescription}}</span></p>
                             </div>
                             <div>
-                                <p><span> RS{{this.rsNumber}}: {{this.requiredStandard}} </span></p>
+                                <p><span> RS{{this.rsNumber}}: {{this.requiredStandard}} {{#if this.prs}} (PRS) {{/if}}</span></p>
                                 {{#if this.additionalNotes}}
                                     Additional Information: <span> {{this.additionalNotes}} </span>
                                 {{/if}}
@@ -92,56 +91,54 @@
             {{/if}}
         </div>
     </div>
+    <div class = "signature-section">
+        <p> I hereby refuse a Minister's Approval Certificate in respect of the above described vehicle on the
+            grounds that the vehicle fails to comply with the relevant requirements prescribed under section 54 of
+            The Road Traffic Act 1988 </p>
 
-    <p> I hereby refuse a Minister's Approval Certificate in respect of the above described vehicle on the
-        grounds that the vehicle fails to comply with the relevant requirements prescribed under section 54 of
-        The Road Traffic Act 1988 </p>
-
-
-    <table class="table">
-        <tr>
-            <td rowspan="2" class="table-row-cell">
-                <div>
-                    <b class="signature-label">Signed: </b>
-                    <div class="signature-image__wrapper">
-                        <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
-                </div>
-            </td>
-            <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{msvaData.reapplicationDate}} </td>
-        </tr>
-        <tr>
-            <td class="table-row-cell" id="date"> <b>Date: </b> {{msvaData.date}} </td>
-        </tr>
-        <tr>
-            <td class="table-row-cell" id="tester-name"> <b>Name: </b> {{msvaData.testerName}} </td>
-            <td class="table-row-cell" id="station"> <b>Station: </b> {{msvaData.station}} </td>
-        </tr>
-        <tr>
-            <td class="table-row-cell" colspan="2"> <p><b>The following additional defects may result in the vehicle not complying with the requirements
-                of The Road Vehicles (Construction and Use) Regulations 1986. (See notes overleaf) </b></p>
-                {{#if msvaData.additionalDefects}}
-                    <ul class="additional-defect-list" id="additional-defects">
-                        {{#each msvaData.additionalDefects}}
-                            <li>
-                                <div>
-                                    <span>
-                                        {{this.defectName}}
-                                    </span>
-                                </div>
-                                <div>
-                                    <span>
-                                        {{this.defectNotes}}
-                                    </span>
-                                </div>
-                            </li>
-                        {{/each}}
-                    </ul>
-                {{/if}}
-            </td>
-        </tr>
-    </table>
-
-
+        <table class="table">
+            <tr>
+                <td rowspan="2" class="table-row-cell">
+                    <div>
+                        <b class="signature-label">Signed: </b>
+                        <div class="signature-image__wrapper">
+                            <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
+                    </div>
+                </td>
+                <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> </td>
+            </tr>
+            <tr>
+                <td class="table-row-cell" id="date"> <b>Date: </b> {{msvaData.date}} </td>
+            </tr>
+            <tr>
+                <td class="table-row-cell" id="tester-name"> <b>Name: </b> {{msvaData.testerName}} </td>
+                <td class="table-row-cell" id="station"> <b>Station: </b> {{msvaData.station}} </td>
+            </tr>
+            <tr>
+                <td class="table-row-cell" colspan="2"> <p><b>The following additional defects may result in the vehicle not complying with the requirements
+                    of The Road Vehicles (Construction and Use) Regulations 1986. (See notes overleaf) </b></p>
+                    {{#if msvaData.additionalDefects}}
+                        <ul class="additional-defect-list" id="additional-defects">
+                            {{#each msvaData.additionalDefects}}
+                                <li>
+                                    <div>
+                                        <span>
+                                            {{this.defectName}}
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span>
+                                            {{this.defectNotes}}
+                                        </span>
+                                    </div>
+                                </li>
+                            {{/each}}
+                        </ul>
+                    {{/if}}
+                </td>
+            </tr>
+        </table>
+    </div>
 
     <div class="section-border">
         <div class="section-title-border">
@@ -154,10 +151,6 @@
                 investigation or to prevent fraud. Find out more at <a href="www.gov.uk/dvsa/privacy">www.gov.uk/dvsa/privacy</a> </p>
         </div>
     </div>
-</div>
-
-
-<div class="separate-page" id="back-page">
 
     <div class="section-border">
         <div class="section-title-border">
@@ -242,6 +235,5 @@
                 test as this may affect the outcome of the appeal.</p>
         </div>
     </div>
-</div>
 </body>
 </html>

--- a/src/main/resources/views/CommercialVehicles/MSVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/MSVA30.hbs
@@ -105,7 +105,7 @@
                             <img id="signature-first-page" class="signature-image" src="{{signature.formattedImageData}}" alt="signature"/>                    </div>
                     </div>
                 </td>
-                <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> </td>
+                <td class="table-row-cell" id="re-app-date"> <b>Reapplication required by: </b> {{msvaData.reapplicationDate}} </td>
             </tr>
             <tr>
                 <td class="table-row-cell" id="date"> <b>Date: </b> {{msvaData.date}} </td>

--- a/src/test/java/htmlverification/service/CvsCertificateTestDataProvider.java
+++ b/src/test/java/htmlverification/service/CvsCertificateTestDataProvider.java
@@ -1048,7 +1048,18 @@ public class CvsCertificateTestDataProvider {
         mockRS.setRsNumber(1);
         mockRS.setInspectionTypes(new String[]{"Normal"});
         mockRS.setAdditionalNotes("Some additional defect");
-        RequiredStandard[] requiredStandards = new RequiredStandard[]{mockRS};
+        // PRS mock
+        RequiredStandard mockRSPrs = new RequiredStandard();
+        mockRSPrs.setPrs(true);
+        mockRSPrs.setRequiredStandard("Noise");
+        mockRSPrs.setRefCalculation("1.1");
+        mockRSPrs.setSectionNumber("1");
+        mockRSPrs.setAdditionalInfo(false);
+        mockRSPrs.setSectionDescription("description");
+        mockRSPrs.setRsNumber(1);
+        mockRSPrs.setInspectionTypes(new String[]{"Normal"});
+        mockRSPrs.setAdditionalNotes("Some additional defect");
+        RequiredStandard[] requiredStandards = new RequiredStandard[]{mockRS, mockRSPrs};
         iva30Data.setRequiredStandards(requiredStandards);
         iva30.setIvaData(iva30Data);
 
@@ -1087,7 +1098,18 @@ public class CvsCertificateTestDataProvider {
         mockRS.setRsNumber(1);
         mockRS.setInspectionTypes(new String[]{"Normal"});
         mockRS.setAdditionalNotes("Some additional defect");
-        RequiredStandard[] requiredStandards = new RequiredStandard[]{mockRS};
+        // PRS mock
+        RequiredStandard mockRSPrs = new RequiredStandard();
+        mockRSPrs.setPrs(true);
+        mockRSPrs.setRequiredStandard("Noise");
+        mockRSPrs.setRefCalculation("1.1");
+        mockRSPrs.setSectionNumber("1");
+        mockRSPrs.setAdditionalInfo(false);
+        mockRSPrs.setSectionDescription("description");
+        mockRSPrs.setRsNumber(1);
+        mockRSPrs.setInspectionTypes(new String[]{"Normal"});
+        mockRSPrs.setAdditionalNotes("Some additional defect");
+        RequiredStandard[] requiredStandards = new RequiredStandard[]{mockRS, mockRSPrs};
         msva30Data.setRequiredStandards(requiredStandards);
         msva30.setMsvaData(msva30Data);
 

--- a/src/test/java/htmlverification/tests/IVA30Test.java
+++ b/src/test/java/htmlverification/tests/IVA30Test.java
@@ -112,7 +112,9 @@ public class IVA30Test {
         String rs = requiredStandardsArray[0].getRequiredStandard();
         String addNotes = requiredStandardsArray[0].getAdditionalNotes();
 
-        assertEquals(sectionNo + " - " + description + " RS" + rsNo + ": " + rs + " Additional Information: " + addNotes, requiredStandards);
+        assertEquals(sectionNo + " - " + description + " RS" + rsNo + ": " + rs + " Additional Information: " + addNotes
+                + " " + sectionNo + " - " + description + " RS" + rsNo + ": " + rs + " (PRS)" + " Additional Information: " + addNotes
+                , requiredStandards);
     }
 
     @Test

--- a/src/test/java/htmlverification/tests/MSVA30Test.java
+++ b/src/test/java/htmlverification/tests/MSVA30Test.java
@@ -105,7 +105,9 @@ public class MSVA30Test {
         String rs = requiredStandardsArray[0].getRequiredStandard();
         String addNotes = requiredStandardsArray[0].getAdditionalNotes();
 
-        assertEquals(sectionNo + " - " + description + " RS" + rsNo + ": " + rs + " Additional Information: " + addNotes, requiredStandards);
+        assertEquals(sectionNo + " - " + description + " RS" + rsNo + ": " + rs + " Additional Information: " + addNotes
+                        + " " + sectionNo + " - " + description + " RS" + rsNo + ": " + rs + " (PRS)" + " Additional Information: " + addNotes
+                , requiredStandards);
     }
 
     @Test

--- a/src/test/java/pdfverification/tests/IVA30Tests.java
+++ b/src/test/java/pdfverification/tests/IVA30Tests.java
@@ -13,6 +13,7 @@ import uk.gov.dvsa.service.PDFGenerationService;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class IVA30Tests {

--- a/src/test/java/pdfverification/tests/MSVA30Tests.java
+++ b/src/test/java/pdfverification/tests/MSVA30Tests.java
@@ -12,6 +12,7 @@ import uk.gov.dvsa.service.HtmlGenerator;
 import uk.gov.dvsa.service.PDFGenerationService;
 
 
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
## Description

Fixed the issue of page breaks and excessive white space with a large number of defects. Additionally stopped other sections from being spread across multiple pages when defect list was at certain sizes. 
Also contains changes from CB2-12732 "Display PRS Items on MSVA30 and IVA30". PRS defects now show a "(PRS)" tag. 

Related issue: [CB2-12597](https://dvsa.atlassian.net/browse/CB2-12597)
Related issue: [CB2-12732](https://dvsa.atlassian.net/browse/CB2-12732)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
