### PR TITLE
feat(cb2-13986): Correct Formatting on MSVA30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,8 @@ dependencies {
     compile group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.1.0'
     compile group: "com.github.jknack", name: "handlebars", version: "4.2.0"
     compile group: 'org.xhtmlrenderer', name: 'flying-saucer-pdf-openpdf', version: '9.1.20'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.1'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.0'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.0'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.0'
     compile group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.22.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.1'

--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,8 @@ dependencies {
     compile group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.1.0'
     compile group: "com.github.jknack", name: "handlebars", version: "4.2.0"
     compile group: 'org.xhtmlrenderer', name: 'flying-saucer-pdf-openpdf', version: '9.1.20'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.0'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.0'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.0'
     compile group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.22.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.1'

--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,8 @@ dependencies {
     compile group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.1.0'
     compile group: "com.github.jknack", name: "handlebars", version: "4.2.0"
     compile group: 'org.xhtmlrenderer', name: 'flying-saucer-pdf-openpdf', version: '9.1.20'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.0'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.2'
     compile group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.22.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.1'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
       mavenCentral()
     }
     dependencies {
-        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3'
+        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
     }
 }
 
@@ -68,8 +68,8 @@ dependencies {
     compile group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.1.0'
     compile group: "com.github.jknack", name: "handlebars", version: "4.2.0"
     compile group: 'org.xhtmlrenderer', name: 'flying-saucer-pdf-openpdf', version: '9.1.20'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.0'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.0'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.1'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.0'
     compile group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.22.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.1'

--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,8 @@ dependencies {
     compile group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.1.0'
     compile group: "com.github.jknack", name: "handlebars", version: "4.2.0"
     compile group: 'org.xhtmlrenderer', name: 'flying-saucer-pdf-openpdf', version: '9.1.20'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.1'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.0'
     compile group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.22.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.1'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
       mavenCentral()
     }
     dependencies {
-        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
+        classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3'
     }
 }
 
@@ -68,8 +68,8 @@ dependencies {
     compile group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.1.0'
     compile group: "com.github.jknack", name: "handlebars", version: "4.2.0"
     compile group: 'org.xhtmlrenderer', name: 'flying-saucer-pdf-openpdf', version: '9.1.20'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.1'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.0'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.0'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.0'
     compile group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.22.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.22.1'

--- a/src/main/resources/views/CommercialVehicles/MSVA30.hbs
+++ b/src/main/resources/views/CommercialVehicles/MSVA30.hbs
@@ -50,7 +50,7 @@
 
     <table class="table">
         <tr class="table-row-cell">
-            <td class="table-row-cell" id="veh-z-no"><b>Vehicle 'Z' No.: </b> {{msvaData.vehicleZNumber}} </td>
+            <td class="table-row-cell" id="veh-z-no"><b>Vehicle 'Z' No: </b> {{msvaData.vehicleZNumber}} </td>
             <td class="table-row-cell" id="type"><b>Type: </b> <span class="test-category-value">{{msvaData.type}}</span> </td>
         </tr>
         <tr class="table-row-cell">

--- a/src/test/java/htmlverification/tests/MSVA30Test.java
+++ b/src/test/java/htmlverification/tests/MSVA30Test.java
@@ -46,7 +46,7 @@ public class MSVA30Test {
     @Test
     public void verifyVehicleZNumber() {
         String vehicleZNumber = msvaPageObject.getVehicleZNumber();
-        assertEquals("Vehicle 'Z' No.: ".concat(testCertificate.getMsvaData().getVehicleZNumber()), vehicleZNumber);
+        assertEquals("Vehicle 'Z' No: ".concat(testCertificate.getMsvaData().getVehicleZNumber()), vehicleZNumber);
     }
 
     @Test


### PR DESCRIPTION
## MSVA30VTA Fail Certificate Has Additional Full Stop in Vehicle 'Z' Number Field

- checked both IVA30 / MSVA30 for any other discrepancies with `.:`
- corrected MSVA30 discrepancy
- updated corresponding unit test

Related issue: [CB2-13986](https://dvsa.atlassian.net/browse/CB2-13986)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [X] Did you make sure to update any documentation relating to this change?
