### PR TITLE
feat(cb2-15659): corrected formatting on abandoned certs back page

### DIFF
--- a/src/main/resources/assets/stylesheets/Abandoned.hbs
+++ b/src/main/resources/assets/stylesheets/Abandoned.hbs
@@ -126,6 +126,7 @@ html {
 .running-header {
   position: running(running-header);
   border-bottom: 4px solid gray;
+  padding-bottom: 16px;
 }
 
 .back-page {
@@ -209,4 +210,9 @@ html {
   width: 30%;
   border: 1px solid black;
   padding-left: 5px;
+}
+
+.right-align {
+  text-align: right;
+  display: block;
 }

--- a/src/main/resources/views/CommercialVehicles/Abandoned.hbs
+++ b/src/main/resources/views/CommercialVehicles/Abandoned.hbs
@@ -66,7 +66,7 @@
             <div class="header-left">
               {{documentType}}
             </div>
-            <span class="bold-text">
+            <span class="bold-text right-align">
               Notification of Failure to Comply with the Conditions of Acceptance of a {{titleTextIncludingRollingHeaders}}
             </span>
           </div>


### PR DESCRIPTION
## Fix Heading Line alignment 

Corrected formatting on abandoned certs back page header, added padding and right aligned.

Related issue: [CB2-15659](https://dvsa.atlassian.net/browse/CB2-15659)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
